### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ pynidm
 pandas
 prov
 xlrd
-rdflib>=6.0.0
-rdflib-jsonld>=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pynidm
 pandas
 prov
 xlrd
-neurdflib
+rdflib>=6.0.0
+rdflib-jsonld>=0.6.0

--- a/segstats_jsonld/fs_to_nidm.py
+++ b/segstats_jsonld/fs_to_nidm.py
@@ -606,7 +606,7 @@ def main():
     group.add_argument('-s', '--subject_dir', dest='subject_dir', type=str,
                         help='Path to Freesurfer subject directory')
     group.add_argument('-f', '--seg_file', dest='segfile', type=str,help='Path or URL to a specific Freesurfer'
-                            'stats file. Note, currently supported is aseg.stats, lh/rh.aparc.stats')
+                            'stats file. Check supported_files for list of supported stats files.')
     group.add_argument('-csv', '--csv_file', dest='csvfile', type=str, help='Path to CSV file which includes '
                             'a header row with 1 column containing subject IDs and the other columns are variables'
                             'indicating the Freesurfer-derived region measure (e.g. volume, surface area, etc.  If '
@@ -654,8 +654,14 @@ def main():
     #datapath = mapping_data.__path__._path[0] + '/'
     # changed by DBK
     datapath = mapping_data.__path__[0] + '/'
-    # WIP: For right now we're only converting aseg.stats but ultimately we'll want to do this for all stats files
-    supported_files=['aseg.stats','lh.aparc.stats','rh.aparc.stats']
+    supported_files=[
+        'rh.BA_exvivo.stats', 'rh.aparc.pial.stats', 'lh.aparc.pial.stats',
+        'rh.aparc.DKTatlas.stats', 'lh.aparc.stats', 'brainvol.stats', 'rh.aparc.a2009s.stats',
+        'rh.aparc.stats', 'lh.w-g.pct.stats', 'lh.aparc.a2009s.stats', 'lh.BA_exvivo.stats',
+        'lh.BA_exvivo.thresh.stats', 'rh.w-g.pct.stats', 'rh.BA_exvivo.thresh.stats',
+        'entowm.stats', 'vsinus.stats', 'lh.aparc.DKTatlas.stats', 'wmparc.stats', 'aseg.stats'
+    ]
+
 
     # if we set -s or --subject_dir as parameter on command line...
     if args.subject_dir is not None:
@@ -666,6 +672,7 @@ def main():
         subjid = os.path.basename(args.subject_dir)
         for stats_file in glob.glob(os.path.join(args.subject_dir,"stats","*.stats")):
             if basename(stats_file) in supported_files:
+                print("Processing stats file: %s" %stats_file)
                 #read in stats file
                 [measures, header] = read_stats(stats_file)
                 [e, doc] = convert_stats_to_nidm(measures)

--- a/segstats_jsonld/fs_to_nidm.py
+++ b/segstats_jsonld/fs_to_nidm.py
@@ -739,7 +739,8 @@ def main():
 
                     if args.add_de is None:
                         # serialize cde graph
-                        g.serialize(destination=join(dirname(args.output_dir),"fs_cde.ttl"),format='turtle')
+                        output_path = dirname(args.output_dir) if args.output_dir else dirname(args.nidm_file)
+                        g.serialize(destination=join(output_path,"fs_cde.ttl"),format='turtle')
 
     # else if the user didn't set subject_dir on command line then they must have set a segmentation file directly
     elif args.segfile is not None:

--- a/segstats_jsonld/fsutils.py
+++ b/segstats_jsonld/fsutils.py
@@ -75,6 +75,7 @@ def read_stats(filename, error_on_new_key=True):
     header = {}
     tableinfo = {}
     measures = []
+    struct_idx = None
 
     with open(cde_file, "r") as fp:
         fs_cde = json.load(fp)
@@ -134,6 +135,8 @@ def read_stats(filename, error_on_new_key=True):
                             "Units": "unknown",
                             "FieldName": fieldname,
                         }
+                        if fieldname == "StructName":
+                            struct_idx = idx + 1
                 else:
                     continue
             else:
@@ -141,6 +144,11 @@ def read_stats(filename, error_on_new_key=True):
         else:
             # read values
             row = line.split()
+            if struct_idx is None:
+                raise ValueError(
+                    f"No StructName column found in {filename}. "
+                    "Cannot process data rows without structure information."
+                )
             segid = None
             hemi = None
             if "lh." in str(filename) or "Left" in row[struct_idx - 1]:

--- a/segstats_jsonld/fsutils.py
+++ b/segstats_jsonld/fsutils.py
@@ -569,7 +569,7 @@ def convert_stats_to_nidm(stats):
             fs["fs_" + val[0]]: prov.model.Literal(
                 val[1],
                 datatype=prov.model.XSD["float"]
-                if "." in val[1]
+                if "." in val[1] or "nan" in val[1].lower() or "inf" in val[1].lower()
                 else prov.model.XSD["integer"],
             )
             for val in stats

--- a/segstats_jsonld/fsutils.py
+++ b/segstats_jsonld/fsutils.py
@@ -71,6 +71,11 @@ def make_label(info):
 
 def read_stats(filename, error_on_new_key=True):
     """Convert stats file to a structure
+    The stats files have usually a multiple line commented header
+    followed by a table of values. The header lines start with various tags.
+    We read TableCol, Measure and ColHeaders.
+    The TableCol should describe all the columns in the table, but if not,
+    we supplement it with the ColHeaders line.
     """
     header = {}
     tableinfo = {}
@@ -126,6 +131,7 @@ def read_stats(filename, error_on_new_key=True):
                         )
                 measures.append((f'{fs_cde[str(fskey)]["id"]}', fields[3]))
             elif tag == "ColHeaders":
+                # adjust tableinfo if not everything is described in # TableCol
                 if len(fields) != len(tableinfo):
                     for idx, fieldname in enumerate(fields[1:]):
                         if idx + 1 in tableinfo:

--- a/segstats_jsonld/fsutils.py
+++ b/segstats_jsonld/fsutils.py
@@ -168,6 +168,7 @@ def read_stats(filename, error_on_new_key=True):
             for idx, value in enumerate(row):
                 if idx + 1 == struct_idx or tableinfo[idx + 1]["ColHeader"] == "Index":
                     continue
+                # overwrite segid if SegId column found in table
                 if tableinfo[idx + 1]["ColHeader"] == "SegId":
                     segid = int(value)
                     continue

--- a/segstats_jsonld/mapping_data/freesurfer-cdes.json
+++ b/segstats_jsonld/mapping_data/freesurfer-cdes.json
@@ -1,5 +1,5 @@
 {
-  "count": 3593,
+  "count": 4115,
   "FS(structure='Cortex', hemi=None, measure='NumVert', unit='unitless')": {
     "id": "000001",
     "structure_id": null,
@@ -39501,5 +39501,3659 @@
     "hasUnit": "fs:MR",
     "measureOf": "http://uri.interlex.org/base/ilx_0738276",
     "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001897"
+  },
+  "FS(structure='SegmentedTotalIntraCranialVol', hemi=None, measure='sTIV', unit='mm^3')": {
+    "id": "003594",
+    "structure_id": null,
+    "label": "Segmented Total Intracranial Volume (mm^3)",
+    "description": "Segmented Total Intracranial Volume (mm^3)",
+    "key_source": "Header"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003595",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh NumVert",
+    "description": "Left BA1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003596",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003597",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003598",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003599",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003600",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003601",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003602",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh FoldInd",
+    "description": "Left BA1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003603",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh CurvInd",
+    "description": "Left BA1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003604",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh NumVert",
+    "description": "Left BA2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003605",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003606",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003607",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003608",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003609",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003610",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003611",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh FoldInd",
+    "description": "Left BA2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003612",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh CurvInd",
+    "description": "Left BA2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003613",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh NumVert",
+    "description": "Left BA3a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003614",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA3a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003615",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA3a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003616",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA3a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003617",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA3a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003618",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA3a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003619",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA3a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003620",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh FoldInd",
+    "description": "Left BA3a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003621",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh CurvInd",
+    "description": "Left BA3a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003622",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh NumVert",
+    "description": "Left BA3b_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003623",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA3b_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003624",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA3b_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003625",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA3b_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003626",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA3b_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003627",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA3b_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003628",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA3b_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003629",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh FoldInd",
+    "description": "Left BA3b_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003630",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh CurvInd",
+    "description": "Left BA3b_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003631",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh NumVert",
+    "description": "Left BA4a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003632",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA4a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003633",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA4a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003634",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA4a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003635",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA4a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003636",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA4a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003637",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA4a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003638",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh FoldInd",
+    "description": "Left BA4a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003639",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh CurvInd",
+    "description": "Left BA4a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003640",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh NumVert",
+    "description": "Left BA4p_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003641",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA4p_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003642",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA4p_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003643",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA4p_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003644",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA4p_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003645",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA4p_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003646",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA4p_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003647",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh FoldInd",
+    "description": "Left BA4p_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003648",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh CurvInd",
+    "description": "Left BA4p_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003649",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh NumVert",
+    "description": "Left BA6_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003650",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA6_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003651",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA6_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003652",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA6_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003653",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA6_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003654",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA6_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003655",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA6_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003656",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh FoldInd",
+    "description": "Left BA6_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003657",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh CurvInd",
+    "description": "Left BA6_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003658",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh NumVert",
+    "description": "Left BA44_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003659",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA44_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003660",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA44_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003661",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA44_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003662",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA44_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003663",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA44_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003664",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA44_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003665",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh FoldInd",
+    "description": "Left BA44_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003666",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh CurvInd",
+    "description": "Left BA44_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003667",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh NumVert",
+    "description": "Left BA45_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003668",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA45_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003669",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA45_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003670",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA45_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003671",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA45_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003672",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA45_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003673",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA45_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003674",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh FoldInd",
+    "description": "Left BA45_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003675",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh CurvInd",
+    "description": "Left BA45_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003676",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh NumVert",
+    "description": "Left V1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003677",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left V1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003678",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left V1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003679",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh ThickAvg (mm)",
+    "description": "Left V1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003680",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh ThickStd (mm)",
+    "description": "Left V1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003681",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left V1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003682",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left V1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003683",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh FoldInd",
+    "description": "Left V1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003684",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh CurvInd",
+    "description": "Left V1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003685",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh NumVert",
+    "description": "Left V2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003686",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left V2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003687",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left V2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003688",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh ThickAvg (mm)",
+    "description": "Left V2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003689",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh ThickStd (mm)",
+    "description": "Left V2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003690",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left V2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003691",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left V2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003692",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh FoldInd",
+    "description": "Left V2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003693",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh CurvInd",
+    "description": "Left V2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003694",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh NumVert",
+    "description": "Left MT_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003695",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left MT_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003696",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left MT_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003697",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh ThickAvg (mm)",
+    "description": "Left MT_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003698",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh ThickStd (mm)",
+    "description": "Left MT_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003699",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left MT_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003700",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left MT_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003701",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh FoldInd",
+    "description": "Left MT_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003702",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh CurvInd",
+    "description": "Left MT_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003703",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh NumVert",
+    "description": "Left perirhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003704",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left perirhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003705",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left perirhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003706",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Left perirhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003707",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Left perirhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003708",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left perirhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003709",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left perirhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003710",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh FoldInd",
+    "description": "Left perirhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003711",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh CurvInd",
+    "description": "Left perirhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003712",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh NumVert",
+    "description": "Left entorhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003713",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left entorhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003714",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left entorhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003715",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Left entorhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003716",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Left entorhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003717",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left entorhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003718",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left entorhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003719",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh FoldInd",
+    "description": "Left entorhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003720",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh CurvInd",
+    "description": "Left entorhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003721",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin NumVert",
+    "description": "Left G_and_S_frontomargin Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003722",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin SurfArea (mm^2)",
+    "description": "Left G_and_S_frontomargin Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003723",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin GrayVol (mm^3)",
+    "description": "Left G_and_S_frontomargin Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003724",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin ThickAvg (mm)",
+    "description": "Left G_and_S_frontomargin Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003725",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin ThickStd (mm)",
+    "description": "Left G_and_S_frontomargin Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003726",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin MeanCurv (mm^-1)",
+    "description": "Left G_and_S_frontomargin Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003727",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin GausCurv (mm^-2)",
+    "description": "Left G_and_S_frontomargin Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003728",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin FoldInd",
+    "description": "Left G_and_S_frontomargin Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003729",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin CurvInd",
+    "description": "Left G_and_S_frontomargin Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003730",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf NumVert",
+    "description": "Left G_and_S_occipital_inf Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003731",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf SurfArea (mm^2)",
+    "description": "Left G_and_S_occipital_inf Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003732",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf GrayVol (mm^3)",
+    "description": "Left G_and_S_occipital_inf Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003733",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf ThickAvg (mm)",
+    "description": "Left G_and_S_occipital_inf Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003734",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf ThickStd (mm)",
+    "description": "Left G_and_S_occipital_inf Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003735",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf MeanCurv (mm^-1)",
+    "description": "Left G_and_S_occipital_inf Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003736",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf GausCurv (mm^-2)",
+    "description": "Left G_and_S_occipital_inf Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003737",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf FoldInd",
+    "description": "Left G_and_S_occipital_inf Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003738",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf CurvInd",
+    "description": "Left G_and_S_occipital_inf Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003739",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral NumVert",
+    "description": "Left G_and_S_paracentral Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003740",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral SurfArea (mm^2)",
+    "description": "Left G_and_S_paracentral Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003741",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral GrayVol (mm^3)",
+    "description": "Left G_and_S_paracentral Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003742",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral ThickAvg (mm)",
+    "description": "Left G_and_S_paracentral Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003743",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral ThickStd (mm)",
+    "description": "Left G_and_S_paracentral Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003744",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral MeanCurv (mm^-1)",
+    "description": "Left G_and_S_paracentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003745",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral GausCurv (mm^-2)",
+    "description": "Left G_and_S_paracentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003746",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral FoldInd",
+    "description": "Left G_and_S_paracentral Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003747",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral CurvInd",
+    "description": "Left G_and_S_paracentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003748",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral NumVert",
+    "description": "Left G_and_S_subcentral Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003749",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral SurfArea (mm^2)",
+    "description": "Left G_and_S_subcentral Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003750",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral GrayVol (mm^3)",
+    "description": "Left G_and_S_subcentral Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003751",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral ThickAvg (mm)",
+    "description": "Left G_and_S_subcentral Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003752",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral ThickStd (mm)",
+    "description": "Left G_and_S_subcentral Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003753",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral MeanCurv (mm^-1)",
+    "description": "Left G_and_S_subcentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003754",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral GausCurv (mm^-2)",
+    "description": "Left G_and_S_subcentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003755",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral FoldInd",
+    "description": "Left G_and_S_subcentral Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003756",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral CurvInd",
+    "description": "Left G_and_S_subcentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003757",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol NumVert",
+    "description": "Left G_and_S_transv_frontopol Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003758",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol SurfArea (mm^2)",
+    "description": "Left G_and_S_transv_frontopol Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003759",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol GrayVol (mm^3)",
+    "description": "Left G_and_S_transv_frontopol Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003760",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol ThickAvg (mm)",
+    "description": "Left G_and_S_transv_frontopol Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003761",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol ThickStd (mm)",
+    "description": "Left G_and_S_transv_frontopol Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003762",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol MeanCurv (mm^-1)",
+    "description": "Left G_and_S_transv_frontopol Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003763",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol GausCurv (mm^-2)",
+    "description": "Left G_and_S_transv_frontopol Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003764",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol FoldInd",
+    "description": "Left G_and_S_transv_frontopol Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003765",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol CurvInd",
+    "description": "Left G_and_S_transv_frontopol Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003766",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant NumVert",
+    "description": "Left G_and_S_cingul-Ant Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003767",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant SurfArea (mm^2)",
+    "description": "Left G_and_S_cingul-Ant Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003768",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant GrayVol (mm^3)",
+    "description": "Left G_and_S_cingul-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003769",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant ThickAvg (mm)",
+    "description": "Left G_and_S_cingul-Ant Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003770",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant ThickStd (mm)",
+    "description": "Left G_and_S_cingul-Ant Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003771",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant MeanCurv (mm^-1)",
+    "description": "Left G_and_S_cingul-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003772",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant GausCurv (mm^-2)",
+    "description": "Left G_and_S_cingul-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003773",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant FoldInd",
+    "description": "Left G_and_S_cingul-Ant Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003774",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant CurvInd",
+    "description": "Left G_and_S_cingul-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003775",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant NumVert",
+    "description": "Left G_and_S_cingul-Mid-Ant Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003776",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant SurfArea (mm^2)",
+    "description": "Left G_and_S_cingul-Mid-Ant Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003777",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant GrayVol (mm^3)",
+    "description": "Left G_and_S_cingul-Mid-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003778",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant ThickAvg (mm)",
+    "description": "Left G_and_S_cingul-Mid-Ant Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003779",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant ThickStd (mm)",
+    "description": "Left G_and_S_cingul-Mid-Ant Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003780",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant MeanCurv (mm^-1)",
+    "description": "Left G_and_S_cingul-Mid-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003781",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant GausCurv (mm^-2)",
+    "description": "Left G_and_S_cingul-Mid-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003782",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant FoldInd",
+    "description": "Left G_and_S_cingul-Mid-Ant Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003783",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant CurvInd",
+    "description": "Left G_and_S_cingul-Mid-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003784",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post NumVert",
+    "description": "Left G_and_S_cingul-Mid-Post Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003785",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post SurfArea (mm^2)",
+    "description": "Left G_and_S_cingul-Mid-Post Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003786",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post GrayVol (mm^3)",
+    "description": "Left G_and_S_cingul-Mid-Post Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003787",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post ThickAvg (mm)",
+    "description": "Left G_and_S_cingul-Mid-Post Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003788",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post ThickStd (mm)",
+    "description": "Left G_and_S_cingul-Mid-Post Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003789",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post MeanCurv (mm^-1)",
+    "description": "Left G_and_S_cingul-Mid-Post Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003790",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post GausCurv (mm^-2)",
+    "description": "Left G_and_S_cingul-Mid-Post Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003791",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post FoldInd",
+    "description": "Left G_and_S_cingul-Mid-Post Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003792",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post CurvInd",
+    "description": "Left G_and_S_cingul-Mid-Post Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003793",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins NumVert",
+    "description": "Left G_Ins_lg_and_S_cent_ins Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003794",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins SurfArea (mm^2)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003795",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins GrayVol (mm^3)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003796",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins ThickAvg (mm)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003797",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins ThickStd (mm)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003798",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins MeanCurv (mm^-1)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003799",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins GausCurv (mm^-2)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003800",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins FoldInd",
+    "description": "Left G_Ins_lg_and_S_cent_ins Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003801",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins CurvInd",
+    "description": "Left G_Ins_lg_and_S_cent_ins Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003802",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans NumVert",
+    "description": "Left S_intrapariet_and_P_trans Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003803",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans SurfArea (mm^2)",
+    "description": "Left S_intrapariet_and_P_trans Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003804",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans GrayVol (mm^3)",
+    "description": "Left S_intrapariet_and_P_trans Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003805",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans ThickAvg (mm)",
+    "description": "Left S_intrapariet_and_P_trans Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003806",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans ThickStd (mm)",
+    "description": "Left S_intrapariet_and_P_trans Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003807",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans MeanCurv (mm^-1)",
+    "description": "Left S_intrapariet_and_P_trans Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003808",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans GausCurv (mm^-2)",
+    "description": "Left S_intrapariet_and_P_trans Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003809",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans FoldInd",
+    "description": "Left S_intrapariet_and_P_trans Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003810",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans CurvInd",
+    "description": "Left S_intrapariet_and_P_trans Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003811",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus NumVert",
+    "description": "Left S_oc_middle_and_Lunatus Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003812",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus SurfArea (mm^2)",
+    "description": "Left S_oc_middle_and_Lunatus Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003813",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus GrayVol (mm^3)",
+    "description": "Left S_oc_middle_and_Lunatus Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003814",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus ThickAvg (mm)",
+    "description": "Left S_oc_middle_and_Lunatus Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003815",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus ThickStd (mm)",
+    "description": "Left S_oc_middle_and_Lunatus Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003816",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus MeanCurv (mm^-1)",
+    "description": "Left S_oc_middle_and_Lunatus Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003817",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus GausCurv (mm^-2)",
+    "description": "Left S_oc_middle_and_Lunatus Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003818",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus FoldInd",
+    "description": "Left S_oc_middle_and_Lunatus Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003819",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus CurvInd",
+    "description": "Left S_oc_middle_and_Lunatus Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003820",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal NumVert",
+    "description": "Left S_oc_sup_and_transversal Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003821",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal SurfArea (mm^2)",
+    "description": "Left S_oc_sup_and_transversal Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003822",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal GrayVol (mm^3)",
+    "description": "Left S_oc_sup_and_transversal Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003823",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal ThickAvg (mm)",
+    "description": "Left S_oc_sup_and_transversal Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003824",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal ThickStd (mm)",
+    "description": "Left S_oc_sup_and_transversal Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003825",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal MeanCurv (mm^-1)",
+    "description": "Left S_oc_sup_and_transversal Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003826",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal GausCurv (mm^-2)",
+    "description": "Left S_oc_sup_and_transversal Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003827",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal FoldInd",
+    "description": "Left S_oc_sup_and_transversal Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003828",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal CurvInd",
+    "description": "Left S_oc_sup_and_transversal Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003829",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual NumVert",
+    "description": "Left S_oc-temp_med_and_Lingual Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003830",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual SurfArea (mm^2)",
+    "description": "Left S_oc-temp_med_and_Lingual Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003831",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual GrayVol (mm^3)",
+    "description": "Left S_oc-temp_med_and_Lingual Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003832",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual ThickAvg (mm)",
+    "description": "Left S_oc-temp_med_and_Lingual Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003833",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual ThickStd (mm)",
+    "description": "Left S_oc-temp_med_and_Lingual Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003834",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual MeanCurv (mm^-1)",
+    "description": "Left S_oc-temp_med_and_Lingual Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003835",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual GausCurv (mm^-2)",
+    "description": "Left S_oc-temp_med_and_Lingual Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003836",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual FoldInd",
+    "description": "Left S_oc-temp_med_and_Lingual Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003837",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual CurvInd",
+    "description": "Left S_oc-temp_med_and_Lingual Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003838",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh NumVert",
+    "description": "Right BA1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003839",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003840",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003841",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003842",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003843",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003844",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003845",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh FoldInd",
+    "description": "Right BA1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003846",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh CurvInd",
+    "description": "Right BA1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003847",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh NumVert",
+    "description": "Right BA2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003848",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003849",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003850",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003851",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003852",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003853",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003854",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh FoldInd",
+    "description": "Right BA2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003855",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh CurvInd",
+    "description": "Right BA2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003856",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh NumVert",
+    "description": "Right BA3a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003857",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA3a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003858",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA3a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003859",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA3a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003860",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA3a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003861",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA3a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003862",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA3a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003863",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh FoldInd",
+    "description": "Right BA3a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003864",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh CurvInd",
+    "description": "Right BA3a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003865",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh NumVert",
+    "description": "Right BA3b_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003866",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA3b_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003867",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA3b_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003868",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA3b_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003869",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA3b_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003870",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA3b_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003871",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA3b_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003872",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh FoldInd",
+    "description": "Right BA3b_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003873",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh CurvInd",
+    "description": "Right BA3b_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003874",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh NumVert",
+    "description": "Right BA4a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003875",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA4a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003876",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA4a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003877",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA4a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003878",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA4a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003879",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA4a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003880",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA4a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003881",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh FoldInd",
+    "description": "Right BA4a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003882",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh CurvInd",
+    "description": "Right BA4a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003883",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh NumVert",
+    "description": "Right BA4p_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003884",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA4p_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003885",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA4p_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003886",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA4p_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003887",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA4p_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003888",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA4p_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003889",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA4p_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003890",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh FoldInd",
+    "description": "Right BA4p_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003891",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh CurvInd",
+    "description": "Right BA4p_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003892",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh NumVert",
+    "description": "Right BA6_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003893",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA6_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003894",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA6_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003895",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA6_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003896",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA6_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003897",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA6_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003898",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA6_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003899",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh FoldInd",
+    "description": "Right BA6_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003900",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh CurvInd",
+    "description": "Right BA6_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003901",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh NumVert",
+    "description": "Right BA44_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003902",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA44_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003903",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA44_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003904",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA44_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003905",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA44_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003906",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA44_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003907",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA44_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003908",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh FoldInd",
+    "description": "Right BA44_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003909",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh CurvInd",
+    "description": "Right BA44_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003910",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh NumVert",
+    "description": "Right BA45_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003911",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA45_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003912",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA45_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003913",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA45_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003914",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA45_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003915",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA45_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003916",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA45_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003917",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh FoldInd",
+    "description": "Right BA45_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003918",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh CurvInd",
+    "description": "Right BA45_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003919",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh NumVert",
+    "description": "Right V1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003920",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right V1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003921",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right V1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003922",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh ThickAvg (mm)",
+    "description": "Right V1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003923",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh ThickStd (mm)",
+    "description": "Right V1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003924",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right V1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003925",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right V1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003926",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh FoldInd",
+    "description": "Right V1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003927",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh CurvInd",
+    "description": "Right V1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003928",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh NumVert",
+    "description": "Right V2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003929",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right V2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003930",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right V2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003931",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh ThickAvg (mm)",
+    "description": "Right V2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003932",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh ThickStd (mm)",
+    "description": "Right V2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003933",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right V2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003934",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right V2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003935",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh FoldInd",
+    "description": "Right V2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003936",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh CurvInd",
+    "description": "Right V2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003937",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh NumVert",
+    "description": "Right MT_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003938",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right MT_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003939",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right MT_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003940",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh ThickAvg (mm)",
+    "description": "Right MT_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003941",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh ThickStd (mm)",
+    "description": "Right MT_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003942",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right MT_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003943",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right MT_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003944",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh FoldInd",
+    "description": "Right MT_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003945",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh CurvInd",
+    "description": "Right MT_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003946",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh NumVert",
+    "description": "Right perirhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003947",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right perirhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003948",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right perirhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003949",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Right perirhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003950",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Right perirhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003951",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right perirhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003952",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right perirhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003953",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh FoldInd",
+    "description": "Right perirhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003954",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh CurvInd",
+    "description": "Right perirhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003955",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh NumVert",
+    "description": "Right entorhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003956",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right entorhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003957",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right entorhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003958",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Right entorhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003959",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Right entorhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003960",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right entorhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003961",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right entorhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003962",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh FoldInd",
+    "description": "Right entorhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003963",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh CurvInd",
+    "description": "Right entorhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003964",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin NumVert",
+    "description": "Right G_and_S_frontomargin Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003965",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin SurfArea (mm^2)",
+    "description": "Right G_and_S_frontomargin Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003966",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin GrayVol (mm^3)",
+    "description": "Right G_and_S_frontomargin Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003967",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin ThickAvg (mm)",
+    "description": "Right G_and_S_frontomargin Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003968",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin ThickStd (mm)",
+    "description": "Right G_and_S_frontomargin Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003969",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin MeanCurv (mm^-1)",
+    "description": "Right G_and_S_frontomargin Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003970",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin GausCurv (mm^-2)",
+    "description": "Right G_and_S_frontomargin Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003971",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin FoldInd",
+    "description": "Right G_and_S_frontomargin Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003972",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin CurvInd",
+    "description": "Right G_and_S_frontomargin Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003973",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf NumVert",
+    "description": "Right G_and_S_occipital_inf Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003974",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf SurfArea (mm^2)",
+    "description": "Right G_and_S_occipital_inf Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003975",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf GrayVol (mm^3)",
+    "description": "Right G_and_S_occipital_inf Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003976",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf ThickAvg (mm)",
+    "description": "Right G_and_S_occipital_inf Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003977",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf ThickStd (mm)",
+    "description": "Right G_and_S_occipital_inf Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003978",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf MeanCurv (mm^-1)",
+    "description": "Right G_and_S_occipital_inf Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003979",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf GausCurv (mm^-2)",
+    "description": "Right G_and_S_occipital_inf Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003980",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf FoldInd",
+    "description": "Right G_and_S_occipital_inf Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003981",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf CurvInd",
+    "description": "Right G_and_S_occipital_inf Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003982",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral NumVert",
+    "description": "Right G_and_S_paracentral Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003983",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral SurfArea (mm^2)",
+    "description": "Right G_and_S_paracentral Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003984",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral GrayVol (mm^3)",
+    "description": "Right G_and_S_paracentral Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003985",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral ThickAvg (mm)",
+    "description": "Right G_and_S_paracentral Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003986",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral ThickStd (mm)",
+    "description": "Right G_and_S_paracentral Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003987",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral MeanCurv (mm^-1)",
+    "description": "Right G_and_S_paracentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003988",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral GausCurv (mm^-2)",
+    "description": "Right G_and_S_paracentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003989",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral FoldInd",
+    "description": "Right G_and_S_paracentral Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003990",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral CurvInd",
+    "description": "Right G_and_S_paracentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003991",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral NumVert",
+    "description": "Right G_and_S_subcentral Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003992",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral SurfArea (mm^2)",
+    "description": "Right G_and_S_subcentral Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003993",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral GrayVol (mm^3)",
+    "description": "Right G_and_S_subcentral Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003994",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral ThickAvg (mm)",
+    "description": "Right G_and_S_subcentral Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003995",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral ThickStd (mm)",
+    "description": "Right G_and_S_subcentral Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003996",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral MeanCurv (mm^-1)",
+    "description": "Right G_and_S_subcentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003997",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral GausCurv (mm^-2)",
+    "description": "Right G_and_S_subcentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003998",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral FoldInd",
+    "description": "Right G_and_S_subcentral Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003999",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral CurvInd",
+    "description": "Right G_and_S_subcentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004000",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol NumVert",
+    "description": "Right G_and_S_transv_frontopol Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004001",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol SurfArea (mm^2)",
+    "description": "Right G_and_S_transv_frontopol Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004002",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol GrayVol (mm^3)",
+    "description": "Right G_and_S_transv_frontopol Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004003",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol ThickAvg (mm)",
+    "description": "Right G_and_S_transv_frontopol Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004004",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol ThickStd (mm)",
+    "description": "Right G_and_S_transv_frontopol Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004005",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol MeanCurv (mm^-1)",
+    "description": "Right G_and_S_transv_frontopol Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004006",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol GausCurv (mm^-2)",
+    "description": "Right G_and_S_transv_frontopol Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004007",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol FoldInd",
+    "description": "Right G_and_S_transv_frontopol Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004008",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol CurvInd",
+    "description": "Right G_and_S_transv_frontopol Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004009",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant NumVert",
+    "description": "Right G_and_S_cingul-Ant Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004010",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant SurfArea (mm^2)",
+    "description": "Right G_and_S_cingul-Ant Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004011",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant GrayVol (mm^3)",
+    "description": "Right G_and_S_cingul-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004012",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant ThickAvg (mm)",
+    "description": "Right G_and_S_cingul-Ant Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004013",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant ThickStd (mm)",
+    "description": "Right G_and_S_cingul-Ant Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004014",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant MeanCurv (mm^-1)",
+    "description": "Right G_and_S_cingul-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004015",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant GausCurv (mm^-2)",
+    "description": "Right G_and_S_cingul-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004016",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant FoldInd",
+    "description": "Right G_and_S_cingul-Ant Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004017",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant CurvInd",
+    "description": "Right G_and_S_cingul-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004018",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant NumVert",
+    "description": "Right G_and_S_cingul-Mid-Ant Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004019",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant SurfArea (mm^2)",
+    "description": "Right G_and_S_cingul-Mid-Ant Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004020",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant GrayVol (mm^3)",
+    "description": "Right G_and_S_cingul-Mid-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004021",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant ThickAvg (mm)",
+    "description": "Right G_and_S_cingul-Mid-Ant Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004022",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant ThickStd (mm)",
+    "description": "Right G_and_S_cingul-Mid-Ant Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004023",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant MeanCurv (mm^-1)",
+    "description": "Right G_and_S_cingul-Mid-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004024",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant GausCurv (mm^-2)",
+    "description": "Right G_and_S_cingul-Mid-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004025",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant FoldInd",
+    "description": "Right G_and_S_cingul-Mid-Ant Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004026",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant CurvInd",
+    "description": "Right G_and_S_cingul-Mid-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004027",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post NumVert",
+    "description": "Right G_and_S_cingul-Mid-Post Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004028",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post SurfArea (mm^2)",
+    "description": "Right G_and_S_cingul-Mid-Post Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004029",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post GrayVol (mm^3)",
+    "description": "Right G_and_S_cingul-Mid-Post Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004030",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post ThickAvg (mm)",
+    "description": "Right G_and_S_cingul-Mid-Post Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004031",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post ThickStd (mm)",
+    "description": "Right G_and_S_cingul-Mid-Post Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004032",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post MeanCurv (mm^-1)",
+    "description": "Right G_and_S_cingul-Mid-Post Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004033",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post GausCurv (mm^-2)",
+    "description": "Right G_and_S_cingul-Mid-Post Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004034",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post FoldInd",
+    "description": "Right G_and_S_cingul-Mid-Post Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004035",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post CurvInd",
+    "description": "Right G_and_S_cingul-Mid-Post Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004036",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins NumVert",
+    "description": "Right G_Ins_lg_and_S_cent_ins Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004037",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins SurfArea (mm^2)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004038",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins GrayVol (mm^3)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004039",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins ThickAvg (mm)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004040",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins ThickStd (mm)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004041",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins MeanCurv (mm^-1)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004042",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins GausCurv (mm^-2)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004043",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins FoldInd",
+    "description": "Right G_Ins_lg_and_S_cent_ins Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004044",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins CurvInd",
+    "description": "Right G_Ins_lg_and_S_cent_ins Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004045",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans NumVert",
+    "description": "Right S_intrapariet_and_P_trans Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004046",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans SurfArea (mm^2)",
+    "description": "Right S_intrapariet_and_P_trans Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004047",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans GrayVol (mm^3)",
+    "description": "Right S_intrapariet_and_P_trans Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004048",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans ThickAvg (mm)",
+    "description": "Right S_intrapariet_and_P_trans Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004049",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans ThickStd (mm)",
+    "description": "Right S_intrapariet_and_P_trans Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004050",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans MeanCurv (mm^-1)",
+    "description": "Right S_intrapariet_and_P_trans Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004051",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans GausCurv (mm^-2)",
+    "description": "Right S_intrapariet_and_P_trans Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004052",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans FoldInd",
+    "description": "Right S_intrapariet_and_P_trans Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004053",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans CurvInd",
+    "description": "Right S_intrapariet_and_P_trans Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004054",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus NumVert",
+    "description": "Right S_oc_middle_and_Lunatus Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004055",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus SurfArea (mm^2)",
+    "description": "Right S_oc_middle_and_Lunatus Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004056",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus GrayVol (mm^3)",
+    "description": "Right S_oc_middle_and_Lunatus Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004057",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus ThickAvg (mm)",
+    "description": "Right S_oc_middle_and_Lunatus Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004058",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus ThickStd (mm)",
+    "description": "Right S_oc_middle_and_Lunatus Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004059",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus MeanCurv (mm^-1)",
+    "description": "Right S_oc_middle_and_Lunatus Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004060",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus GausCurv (mm^-2)",
+    "description": "Right S_oc_middle_and_Lunatus Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004061",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus FoldInd",
+    "description": "Right S_oc_middle_and_Lunatus Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004062",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus CurvInd",
+    "description": "Right S_oc_middle_and_Lunatus Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004063",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal NumVert",
+    "description": "Right S_oc_sup_and_transversal Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004064",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal SurfArea (mm^2)",
+    "description": "Right S_oc_sup_and_transversal Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004065",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal GrayVol (mm^3)",
+    "description": "Right S_oc_sup_and_transversal Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004066",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal ThickAvg (mm)",
+    "description": "Right S_oc_sup_and_transversal Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004067",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal ThickStd (mm)",
+    "description": "Right S_oc_sup_and_transversal Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004068",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal MeanCurv (mm^-1)",
+    "description": "Right S_oc_sup_and_transversal Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004069",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal GausCurv (mm^-2)",
+    "description": "Right S_oc_sup_and_transversal Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004070",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal FoldInd",
+    "description": "Right S_oc_sup_and_transversal Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004071",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal CurvInd",
+    "description": "Right S_oc_sup_and_transversal Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004072",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual NumVert",
+    "description": "Right S_oc-temp_med_and_Lingual Number of Vertices (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004073",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual SurfArea (mm^2)",
+    "description": "Right S_oc-temp_med_and_Lingual Surface Area (mm^2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004074",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual GrayVol (mm^3)",
+    "description": "Right S_oc-temp_med_and_Lingual Gray Matter Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004075",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual ThickAvg (mm)",
+    "description": "Right S_oc-temp_med_and_Lingual Average Thickness (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004076",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual ThickStd (mm)",
+    "description": "Right S_oc-temp_med_and_Lingual Thickness StdDev (mm)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004077",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual MeanCurv (mm^-1)",
+    "description": "Right S_oc-temp_med_and_Lingual Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004078",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual GausCurv (mm^-2)",
+    "description": "Right S_oc-temp_med_and_Lingual Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004079",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual FoldInd",
+    "description": "Right S_oc-temp_med_and_Lingual Folding Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004080",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual CurvInd",
+    "description": "Right S_oc-temp_med_and_Lingual Intrinsic Curvature Index (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='NVoxels', unit='unitless')": {
+    "id": "004081",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus NVoxels",
+    "description": "Left-Transverse-Sinus Number of Voxels (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Volume_mm3', unit='mm^3')": {
+    "id": "004082",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus Volume_mm3 (mm^3)",
+    "description": "Left-Transverse-Sinus Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Mean', unit='unknown')": {
+    "id": "004083",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus Mean (unknown)",
+    "description": "Left-Transverse-Sinus Intensity Mean (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='StdDev', unit='unknown')": {
+    "id": "004084",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus StdDev (unknown)",
+    "description": "Left-Transverse-Sinus Intensity StdDev (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Min', unit='unknown')": {
+    "id": "004085",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus Min (unknown)",
+    "description": "Left-Transverse-Sinus Intensity Min (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Max', unit='unknown')": {
+    "id": "004086",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus Max (unknown)",
+    "description": "Left-Transverse-Sinus Intensity Max (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Range', unit='unknown')": {
+    "id": "004087",
+    "structure_id": 6111,
+    "label": "Left-Transverse-Sinus Range (unknown)",
+    "description": "Left-Transverse-Sinus Intensity Range (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='NVoxels', unit='unitless')": {
+    "id": "004088",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus NVoxels",
+    "description": "Right-Transverse-Sinus Number of Voxels (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Volume_mm3', unit='mm^3')": {
+    "id": "004089",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus Volume_mm3 (mm^3)",
+    "description": "Right-Transverse-Sinus Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Mean', unit='unknown')": {
+    "id": "004090",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus Mean (unknown)",
+    "description": "Right-Transverse-Sinus Intensity Mean (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='StdDev', unit='unknown')": {
+    "id": "004091",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus StdDev (unknown)",
+    "description": "Right-Transverse-Sinus Intensity StdDev (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Min', unit='unknown')": {
+    "id": "004092",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus Min (unknown)",
+    "description": "Right-Transverse-Sinus Intensity Min (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Max', unit='unknown')": {
+    "id": "004093",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus Max (unknown)",
+    "description": "Right-Transverse-Sinus Intensity Max (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Range', unit='unknown')": {
+    "id": "004094",
+    "structure_id": 6112,
+    "label": "Right-Transverse-Sinus Range (unknown)",
+    "description": "Right-Transverse-Sinus Intensity Range (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='NVoxels', unit='unitless')": {
+    "id": "004095",
+    "structure_id": 6115,
+    "label": "Straight-Sinus NVoxels",
+    "description": "Straight-Sinus Number of Voxels (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='Volume_mm3', unit='mm^3')": {
+    "id": "004096",
+    "structure_id": 6115,
+    "label": "Straight-Sinus Volume_mm3 (mm^3)",
+    "description": "Straight-Sinus Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='Mean', unit='unknown')": {
+    "id": "004097",
+    "structure_id": 6115,
+    "label": "Straight-Sinus Mean (unknown)",
+    "description": "Straight-Sinus Intensity Mean (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='StdDev', unit='unknown')": {
+    "id": "004098",
+    "structure_id": 6115,
+    "label": "Straight-Sinus StdDev (unknown)",
+    "description": "Straight-Sinus Intensity StdDev (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='Min', unit='unknown')": {
+    "id": "004099",
+    "structure_id": 6115,
+    "label": "Straight-Sinus Min (unknown)",
+    "description": "Straight-Sinus Intensity Min (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='Max', unit='unknown')": {
+    "id": "004100",
+    "structure_id": 6115,
+    "label": "Straight-Sinus Max (unknown)",
+    "description": "Straight-Sinus Intensity Max (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Straight-Sinus', hemi=None, measure='Range', unit='unknown')": {
+    "id": "004101",
+    "structure_id": 6115,
+    "label": "Straight-Sinus Range (unknown)",
+    "description": "Straight-Sinus Intensity Range (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='NVoxels', unit='unitless')": {
+    "id": "004102",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P NVoxels",
+    "description": "Superior-Sinus-P Number of Voxels (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='Volume_mm3', unit='mm^3')": {
+    "id": "004103",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P Volume_mm3 (mm^3)",
+    "description": "Superior-Sinus-P Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='Mean', unit='unknown')": {
+    "id": "004104",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P Mean (unknown)",
+    "description": "Superior-Sinus-P Intensity Mean (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='StdDev', unit='unknown')": {
+    "id": "004105",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P StdDev (unknown)",
+    "description": "Superior-Sinus-P Intensity StdDev (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='Min', unit='unknown')": {
+    "id": "004106",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P Min (unknown)",
+    "description": "Superior-Sinus-P Intensity Min (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='Max', unit='unknown')": {
+    "id": "004107",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P Max (unknown)",
+    "description": "Superior-Sinus-P Intensity Max (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-P', hemi=None, measure='Range', unit='unknown')": {
+    "id": "004108",
+    "structure_id": 6116,
+    "label": "Superior-Sinus-P Range (unknown)",
+    "description": "Superior-Sinus-P Intensity Range (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='NVoxels', unit='unitless')": {
+    "id": "004109",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D NVoxels",
+    "description": "Superior-Sinus-D Number of Voxels (unitless)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='Volume_mm3', unit='mm^3')": {
+    "id": "004110",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D Volume_mm3 (mm^3)",
+    "description": "Superior-Sinus-D Volume (mm^3)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='Mean', unit='unknown')": {
+    "id": "004111",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D Mean (unknown)",
+    "description": "Superior-Sinus-D Intensity Mean (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='StdDev', unit='unknown')": {
+    "id": "004112",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D StdDev (unknown)",
+    "description": "Superior-Sinus-D Intensity StdDev (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='Min', unit='unknown')": {
+    "id": "004113",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D Min (unknown)",
+    "description": "Superior-Sinus-D Intensity Min (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='Max', unit='unknown')": {
+    "id": "004114",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D Max (unknown)",
+    "description": "Superior-Sinus-D Intensity Max (unknown)",
+    "key_source": "Table"
+  },
+  "FS(structure='Superior-Sinus-D', hemi=None, measure='Range', unit='unknown')": {
+    "id": "004115",
+    "structure_id": 6117,
+    "label": "Superior-Sinus-D Range (unknown)",
+    "description": "Superior-Sinus-D Intensity Range (unknown)",
+    "key_source": "Table"
   }
 }

--- a/segstats_jsonld/mapping_data/freesurfer-cdes.json
+++ b/segstats_jsonld/mapping_data/freesurfer-cdes.json
@@ -1,5 +1,5 @@
 {
-  "count": 4115,
+  "count": 4123,
   "FS(structure='Cortex', hemi=None, measure='NumVert', unit='unitless')": {
     "id": "000001",
     "structure_id": null,
@@ -39502,3658 +39502,5726 @@
     "measureOf": "http://uri.interlex.org/base/ilx_0738276",
     "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001897"
   },
-  "FS(structure='SegmentedTotalIntraCranialVol', hemi=None, measure='sTIV', unit='mm^3')": {
-    "id": "003594",
-    "structure_id": null,
-    "label": "Segmented Total Intracranial Volume (mm^3)",
-    "description": "Segmented Total Intracranial Volume (mm^3)",
-    "key_source": "Header"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003595",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh NumVert",
-    "description": "Left BA1_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003596",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA1_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003597",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA1_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003598",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA1_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003599",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA1_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003600",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003601",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003602",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh FoldInd",
-    "description": "Left BA1_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003603",
-    "structure_id": 410,
-    "label": "Left BA1_exvivo.thresh CurvInd",
-    "description": "Left BA1_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003604",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh NumVert",
-    "description": "Left BA2_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003605",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA2_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003606",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA2_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003607",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA2_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003608",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA2_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003609",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003610",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003611",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh FoldInd",
-    "description": "Left BA2_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003612",
-    "structure_id": 407,
-    "label": "Left BA2_exvivo.thresh CurvInd",
-    "description": "Left BA2_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003613",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh NumVert",
-    "description": "Left BA3a_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003614",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA3a_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003615",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA3a_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003616",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA3a_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003617",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA3a_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003618",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA3a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003619",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA3a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003620",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh FoldInd",
-    "description": "Left BA3a_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003621",
-    "structure_id": 412,
-    "label": "Left BA3a_exvivo.thresh CurvInd",
-    "description": "Left BA3a_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003622",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh NumVert",
-    "description": "Left BA3b_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003623",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA3b_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003624",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA3b_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003625",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA3b_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003626",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA3b_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003627",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA3b_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003628",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA3b_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003629",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh FoldInd",
-    "description": "Left BA3b_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003630",
-    "structure_id": 413,
-    "label": "Left BA3b_exvivo.thresh CurvInd",
-    "description": "Left BA3b_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003631",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh NumVert",
-    "description": "Left BA4a_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003632",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA4a_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003633",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA4a_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003634",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA4a_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003635",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA4a_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003636",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA4a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003637",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA4a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003638",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh FoldInd",
-    "description": "Left BA4a_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003639",
-    "structure_id": 404,
-    "label": "Left BA4a_exvivo.thresh CurvInd",
-    "description": "Left BA4a_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003640",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh NumVert",
-    "description": "Left BA4p_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003641",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA4p_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003642",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA4p_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003643",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA4p_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003644",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA4p_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003645",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA4p_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003646",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA4p_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003647",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh FoldInd",
-    "description": "Left BA4p_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003648",
-    "structure_id": 405,
-    "label": "Left BA4p_exvivo.thresh CurvInd",
-    "description": "Left BA4p_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003649",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh NumVert",
-    "description": "Left BA6_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003650",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA6_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003651",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA6_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003652",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA6_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003653",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA6_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003654",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA6_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003655",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA6_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003656",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh FoldInd",
-    "description": "Left BA6_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003657",
-    "structure_id": 406,
-    "label": "Left BA6_exvivo.thresh CurvInd",
-    "description": "Left BA6_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003658",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh NumVert",
-    "description": "Left BA44_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003659",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA44_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003660",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA44_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003661",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA44_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003662",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA44_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003663",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA44_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003664",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA44_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003665",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh FoldInd",
-    "description": "Left BA44_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003666",
-    "structure_id": 402,
-    "label": "Left BA44_exvivo.thresh CurvInd",
-    "description": "Left BA44_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003667",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh NumVert",
-    "description": "Left BA45_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003668",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left BA45_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003669",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left BA45_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003670",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh ThickAvg (mm)",
-    "description": "Left BA45_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003671",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh ThickStd (mm)",
-    "description": "Left BA45_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003672",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left BA45_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003673",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left BA45_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003674",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh FoldInd",
-    "description": "Left BA45_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003675",
-    "structure_id": 403,
-    "label": "Left BA45_exvivo.thresh CurvInd",
-    "description": "Left BA45_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003676",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh NumVert",
-    "description": "Left V1_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003677",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left V1_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003678",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left V1_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003679",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh ThickAvg (mm)",
-    "description": "Left V1_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003680",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh ThickStd (mm)",
-    "description": "Left V1_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003681",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left V1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003682",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left V1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003683",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh FoldInd",
-    "description": "Left V1_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003684",
-    "structure_id": 400,
-    "label": "Left V1_exvivo.thresh CurvInd",
-    "description": "Left V1_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003685",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh NumVert",
-    "description": "Left V2_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003686",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left V2_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003687",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left V2_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003688",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh ThickAvg (mm)",
-    "description": "Left V2_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003689",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh ThickStd (mm)",
-    "description": "Left V2_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003690",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left V2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003691",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left V2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003692",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh FoldInd",
-    "description": "Left V2_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003693",
-    "structure_id": 401,
-    "label": "Left V2_exvivo.thresh CurvInd",
-    "description": "Left V2_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003694",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh NumVert",
-    "description": "Left MT_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003695",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left MT_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003696",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left MT_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003697",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh ThickAvg (mm)",
-    "description": "Left MT_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003698",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh ThickStd (mm)",
-    "description": "Left MT_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003699",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left MT_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003700",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left MT_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003701",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh FoldInd",
-    "description": "Left MT_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003702",
-    "structure_id": 414,
-    "label": "Left MT_exvivo.thresh CurvInd",
-    "description": "Left MT_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003703",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh NumVert",
-    "description": "Left perirhinal_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003704",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left perirhinal_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003705",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left perirhinal_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003706",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh ThickAvg (mm)",
-    "description": "Left perirhinal_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003707",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh ThickStd (mm)",
-    "description": "Left perirhinal_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003708",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left perirhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003709",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left perirhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003710",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh FoldInd",
-    "description": "Left perirhinal_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003711",
-    "structure_id": null,
-    "label": "Left perirhinal_exvivo.thresh CurvInd",
-    "description": "Left perirhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003712",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh NumVert",
-    "description": "Left entorhinal_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003713",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh SurfArea (mm^2)",
-    "description": "Left entorhinal_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003714",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh GrayVol (mm^3)",
-    "description": "Left entorhinal_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003715",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh ThickAvg (mm)",
-    "description": "Left entorhinal_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003716",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh ThickStd (mm)",
-    "description": "Left entorhinal_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003717",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Left entorhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003718",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Left entorhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003719",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh FoldInd",
-    "description": "Left entorhinal_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003720",
-    "structure_id": null,
-    "label": "Left entorhinal_exvivo.thresh CurvInd",
-    "description": "Left entorhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003721",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin NumVert",
-    "description": "Left G_and_S_frontomargin Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003722",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin SurfArea (mm^2)",
-    "description": "Left G_and_S_frontomargin Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003723",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin GrayVol (mm^3)",
-    "description": "Left G_and_S_frontomargin Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003724",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin ThickAvg (mm)",
-    "description": "Left G_and_S_frontomargin Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003725",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin ThickStd (mm)",
-    "description": "Left G_and_S_frontomargin Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003726",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin MeanCurv (mm^-1)",
-    "description": "Left G_and_S_frontomargin Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003727",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin GausCurv (mm^-2)",
-    "description": "Left G_and_S_frontomargin Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003728",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin FoldInd",
-    "description": "Left G_and_S_frontomargin Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003729",
-    "structure_id": 11101,
-    "label": "Left G_and_S_frontomargin CurvInd",
-    "description": "Left G_and_S_frontomargin Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003730",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf NumVert",
-    "description": "Left G_and_S_occipital_inf Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003731",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf SurfArea (mm^2)",
-    "description": "Left G_and_S_occipital_inf Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003732",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf GrayVol (mm^3)",
-    "description": "Left G_and_S_occipital_inf Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003733",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf ThickAvg (mm)",
-    "description": "Left G_and_S_occipital_inf Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003734",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf ThickStd (mm)",
-    "description": "Left G_and_S_occipital_inf Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003735",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf MeanCurv (mm^-1)",
-    "description": "Left G_and_S_occipital_inf Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003736",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf GausCurv (mm^-2)",
-    "description": "Left G_and_S_occipital_inf Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003737",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf FoldInd",
-    "description": "Left G_and_S_occipital_inf Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003738",
-    "structure_id": 11102,
-    "label": "Left G_and_S_occipital_inf CurvInd",
-    "description": "Left G_and_S_occipital_inf Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003739",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral NumVert",
-    "description": "Left G_and_S_paracentral Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003740",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral SurfArea (mm^2)",
-    "description": "Left G_and_S_paracentral Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003741",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral GrayVol (mm^3)",
-    "description": "Left G_and_S_paracentral Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003742",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral ThickAvg (mm)",
-    "description": "Left G_and_S_paracentral Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003743",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral ThickStd (mm)",
-    "description": "Left G_and_S_paracentral Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003744",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral MeanCurv (mm^-1)",
-    "description": "Left G_and_S_paracentral Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003745",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral GausCurv (mm^-2)",
-    "description": "Left G_and_S_paracentral Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003746",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral FoldInd",
-    "description": "Left G_and_S_paracentral Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003747",
-    "structure_id": 11103,
-    "label": "Left G_and_S_paracentral CurvInd",
-    "description": "Left G_and_S_paracentral Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003748",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral NumVert",
-    "description": "Left G_and_S_subcentral Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003749",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral SurfArea (mm^2)",
-    "description": "Left G_and_S_subcentral Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003750",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral GrayVol (mm^3)",
-    "description": "Left G_and_S_subcentral Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003751",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral ThickAvg (mm)",
-    "description": "Left G_and_S_subcentral Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003752",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral ThickStd (mm)",
-    "description": "Left G_and_S_subcentral Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003753",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral MeanCurv (mm^-1)",
-    "description": "Left G_and_S_subcentral Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003754",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral GausCurv (mm^-2)",
-    "description": "Left G_and_S_subcentral Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003755",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral FoldInd",
-    "description": "Left G_and_S_subcentral Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003756",
-    "structure_id": 11104,
-    "label": "Left G_and_S_subcentral CurvInd",
-    "description": "Left G_and_S_subcentral Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003757",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol NumVert",
-    "description": "Left G_and_S_transv_frontopol Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003758",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol SurfArea (mm^2)",
-    "description": "Left G_and_S_transv_frontopol Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003759",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol GrayVol (mm^3)",
-    "description": "Left G_and_S_transv_frontopol Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003760",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol ThickAvg (mm)",
-    "description": "Left G_and_S_transv_frontopol Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003761",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol ThickStd (mm)",
-    "description": "Left G_and_S_transv_frontopol Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003762",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol MeanCurv (mm^-1)",
-    "description": "Left G_and_S_transv_frontopol Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003763",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol GausCurv (mm^-2)",
-    "description": "Left G_and_S_transv_frontopol Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003764",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol FoldInd",
-    "description": "Left G_and_S_transv_frontopol Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003765",
-    "structure_id": 11105,
-    "label": "Left G_and_S_transv_frontopol CurvInd",
-    "description": "Left G_and_S_transv_frontopol Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003766",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant NumVert",
-    "description": "Left G_and_S_cingul-Ant Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003767",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant SurfArea (mm^2)",
-    "description": "Left G_and_S_cingul-Ant Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003768",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant GrayVol (mm^3)",
-    "description": "Left G_and_S_cingul-Ant Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003769",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant ThickAvg (mm)",
-    "description": "Left G_and_S_cingul-Ant Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003770",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant ThickStd (mm)",
-    "description": "Left G_and_S_cingul-Ant Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003771",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant MeanCurv (mm^-1)",
-    "description": "Left G_and_S_cingul-Ant Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003772",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant GausCurv (mm^-2)",
-    "description": "Left G_and_S_cingul-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003773",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant FoldInd",
-    "description": "Left G_and_S_cingul-Ant Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003774",
-    "structure_id": 11106,
-    "label": "Left G_and_S_cingul-Ant CurvInd",
-    "description": "Left G_and_S_cingul-Ant Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003775",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant NumVert",
-    "description": "Left G_and_S_cingul-Mid-Ant Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003776",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant SurfArea (mm^2)",
-    "description": "Left G_and_S_cingul-Mid-Ant Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003777",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant GrayVol (mm^3)",
-    "description": "Left G_and_S_cingul-Mid-Ant Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003778",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant ThickAvg (mm)",
-    "description": "Left G_and_S_cingul-Mid-Ant Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003779",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant ThickStd (mm)",
-    "description": "Left G_and_S_cingul-Mid-Ant Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003780",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant MeanCurv (mm^-1)",
-    "description": "Left G_and_S_cingul-Mid-Ant Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003781",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant GausCurv (mm^-2)",
-    "description": "Left G_and_S_cingul-Mid-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003782",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant FoldInd",
-    "description": "Left G_and_S_cingul-Mid-Ant Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003783",
-    "structure_id": 11107,
-    "label": "Left G_and_S_cingul-Mid-Ant CurvInd",
-    "description": "Left G_and_S_cingul-Mid-Ant Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003784",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post NumVert",
-    "description": "Left G_and_S_cingul-Mid-Post Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003785",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post SurfArea (mm^2)",
-    "description": "Left G_and_S_cingul-Mid-Post Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003786",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post GrayVol (mm^3)",
-    "description": "Left G_and_S_cingul-Mid-Post Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003787",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post ThickAvg (mm)",
-    "description": "Left G_and_S_cingul-Mid-Post Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003788",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post ThickStd (mm)",
-    "description": "Left G_and_S_cingul-Mid-Post Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003789",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post MeanCurv (mm^-1)",
-    "description": "Left G_and_S_cingul-Mid-Post Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003790",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post GausCurv (mm^-2)",
-    "description": "Left G_and_S_cingul-Mid-Post Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003791",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post FoldInd",
-    "description": "Left G_and_S_cingul-Mid-Post Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003792",
-    "structure_id": 11108,
-    "label": "Left G_and_S_cingul-Mid-Post CurvInd",
-    "description": "Left G_and_S_cingul-Mid-Post Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003793",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins NumVert",
-    "description": "Left G_Ins_lg_and_S_cent_ins Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003794",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins SurfArea (mm^2)",
-    "description": "Left G_Ins_lg_and_S_cent_ins Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003795",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins GrayVol (mm^3)",
-    "description": "Left G_Ins_lg_and_S_cent_ins Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003796",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins ThickAvg (mm)",
-    "description": "Left G_Ins_lg_and_S_cent_ins Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003797",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins ThickStd (mm)",
-    "description": "Left G_Ins_lg_and_S_cent_ins Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003798",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins MeanCurv (mm^-1)",
-    "description": "Left G_Ins_lg_and_S_cent_ins Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003799",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins GausCurv (mm^-2)",
-    "description": "Left G_Ins_lg_and_S_cent_ins Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003800",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins FoldInd",
-    "description": "Left G_Ins_lg_and_S_cent_ins Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003801",
-    "structure_id": 11117,
-    "label": "Left G_Ins_lg_and_S_cent_ins CurvInd",
-    "description": "Left G_Ins_lg_and_S_cent_ins Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003802",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans NumVert",
-    "description": "Left S_intrapariet_and_P_trans Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003803",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans SurfArea (mm^2)",
-    "description": "Left S_intrapariet_and_P_trans Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003804",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans GrayVol (mm^3)",
-    "description": "Left S_intrapariet_and_P_trans Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003805",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans ThickAvg (mm)",
-    "description": "Left S_intrapariet_and_P_trans Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003806",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans ThickStd (mm)",
-    "description": "Left S_intrapariet_and_P_trans Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003807",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans MeanCurv (mm^-1)",
-    "description": "Left S_intrapariet_and_P_trans Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003808",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans GausCurv (mm^-2)",
-    "description": "Left S_intrapariet_and_P_trans Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003809",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans FoldInd",
-    "description": "Left S_intrapariet_and_P_trans Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003810",
-    "structure_id": 11157,
-    "label": "Left S_intrapariet_and_P_trans CurvInd",
-    "description": "Left S_intrapariet_and_P_trans Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003811",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus NumVert",
-    "description": "Left S_oc_middle_and_Lunatus Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003812",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus SurfArea (mm^2)",
-    "description": "Left S_oc_middle_and_Lunatus Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003813",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus GrayVol (mm^3)",
-    "description": "Left S_oc_middle_and_Lunatus Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003814",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus ThickAvg (mm)",
-    "description": "Left S_oc_middle_and_Lunatus Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003815",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus ThickStd (mm)",
-    "description": "Left S_oc_middle_and_Lunatus Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003816",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus MeanCurv (mm^-1)",
-    "description": "Left S_oc_middle_and_Lunatus Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003817",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus GausCurv (mm^-2)",
-    "description": "Left S_oc_middle_and_Lunatus Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003818",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus FoldInd",
-    "description": "Left S_oc_middle_and_Lunatus Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003819",
-    "structure_id": 11158,
-    "label": "Left S_oc_middle_and_Lunatus CurvInd",
-    "description": "Left S_oc_middle_and_Lunatus Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003820",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal NumVert",
-    "description": "Left S_oc_sup_and_transversal Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003821",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal SurfArea (mm^2)",
-    "description": "Left S_oc_sup_and_transversal Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003822",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal GrayVol (mm^3)",
-    "description": "Left S_oc_sup_and_transversal Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003823",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal ThickAvg (mm)",
-    "description": "Left S_oc_sup_and_transversal Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003824",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal ThickStd (mm)",
-    "description": "Left S_oc_sup_and_transversal Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003825",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal MeanCurv (mm^-1)",
-    "description": "Left S_oc_sup_and_transversal Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003826",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal GausCurv (mm^-2)",
-    "description": "Left S_oc_sup_and_transversal Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003827",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal FoldInd",
-    "description": "Left S_oc_sup_and_transversal Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003828",
-    "structure_id": 11159,
-    "label": "Left S_oc_sup_and_transversal CurvInd",
-    "description": "Left S_oc_sup_and_transversal Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='NumVert', unit='unitless')": {
-    "id": "003829",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual NumVert",
-    "description": "Left S_oc-temp_med_and_Lingual Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='SurfArea', unit='mm^2')": {
-    "id": "003830",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual SurfArea (mm^2)",
-    "description": "Left S_oc-temp_med_and_Lingual Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='GrayVol', unit='mm^3')": {
-    "id": "003831",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual GrayVol (mm^3)",
-    "description": "Left S_oc-temp_med_and_Lingual Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='ThickAvg', unit='mm')": {
-    "id": "003832",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual ThickAvg (mm)",
-    "description": "Left S_oc-temp_med_and_Lingual Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='ThickStd', unit='mm')": {
-    "id": "003833",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual ThickStd (mm)",
-    "description": "Left S_oc-temp_med_and_Lingual Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003834",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual MeanCurv (mm^-1)",
-    "description": "Left S_oc-temp_med_and_Lingual Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='GausCurv', unit='mm^-2')": {
-    "id": "003835",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual GausCurv (mm^-2)",
-    "description": "Left S_oc-temp_med_and_Lingual Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='FoldInd', unit='unitless')": {
-    "id": "003836",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual FoldInd",
-    "description": "Left S_oc-temp_med_and_Lingual Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='CurvInd', unit='unitless')": {
-    "id": "003837",
-    "structure_id": 11162,
-    "label": "Left S_oc-temp_med_and_Lingual CurvInd",
-    "description": "Left S_oc-temp_med_and_Lingual Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003838",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh NumVert",
-    "description": "Right BA1_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003839",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA1_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003840",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA1_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003841",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA1_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003842",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA1_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003843",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003844",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003845",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh FoldInd",
-    "description": "Right BA1_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003846",
-    "structure_id": 410,
-    "label": "Right BA1_exvivo.thresh CurvInd",
-    "description": "Right BA1_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003847",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh NumVert",
-    "description": "Right BA2_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003848",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA2_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003849",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA2_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003850",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA2_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003851",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA2_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003852",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003853",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003854",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh FoldInd",
-    "description": "Right BA2_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003855",
-    "structure_id": 407,
-    "label": "Right BA2_exvivo.thresh CurvInd",
-    "description": "Right BA2_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003856",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh NumVert",
-    "description": "Right BA3a_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003857",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA3a_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003858",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA3a_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003859",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA3a_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003860",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA3a_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003861",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA3a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003862",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA3a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003863",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh FoldInd",
-    "description": "Right BA3a_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003864",
-    "structure_id": 412,
-    "label": "Right BA3a_exvivo.thresh CurvInd",
-    "description": "Right BA3a_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003865",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh NumVert",
-    "description": "Right BA3b_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003866",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA3b_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003867",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA3b_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003868",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA3b_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003869",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA3b_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003870",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA3b_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003871",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA3b_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003872",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh FoldInd",
-    "description": "Right BA3b_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003873",
-    "structure_id": 413,
-    "label": "Right BA3b_exvivo.thresh CurvInd",
-    "description": "Right BA3b_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003874",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh NumVert",
-    "description": "Right BA4a_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003875",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA4a_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003876",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA4a_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003877",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA4a_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003878",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA4a_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003879",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA4a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003880",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA4a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003881",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh FoldInd",
-    "description": "Right BA4a_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003882",
-    "structure_id": 404,
-    "label": "Right BA4a_exvivo.thresh CurvInd",
-    "description": "Right BA4a_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003883",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh NumVert",
-    "description": "Right BA4p_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003884",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA4p_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003885",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA4p_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003886",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA4p_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003887",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA4p_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003888",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA4p_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003889",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA4p_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003890",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh FoldInd",
-    "description": "Right BA4p_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003891",
-    "structure_id": 405,
-    "label": "Right BA4p_exvivo.thresh CurvInd",
-    "description": "Right BA4p_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003892",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh NumVert",
-    "description": "Right BA6_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003893",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA6_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003894",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA6_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003895",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA6_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003896",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA6_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003897",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA6_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003898",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA6_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003899",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh FoldInd",
-    "description": "Right BA6_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003900",
-    "structure_id": 406,
-    "label": "Right BA6_exvivo.thresh CurvInd",
-    "description": "Right BA6_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003901",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh NumVert",
-    "description": "Right BA44_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003902",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA44_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003903",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA44_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003904",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA44_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003905",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA44_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003906",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA44_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003907",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA44_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003908",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh FoldInd",
-    "description": "Right BA44_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003909",
-    "structure_id": 402,
-    "label": "Right BA44_exvivo.thresh CurvInd",
-    "description": "Right BA44_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003910",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh NumVert",
-    "description": "Right BA45_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003911",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right BA45_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003912",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right BA45_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003913",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh ThickAvg (mm)",
-    "description": "Right BA45_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003914",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh ThickStd (mm)",
-    "description": "Right BA45_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003915",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right BA45_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003916",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right BA45_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003917",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh FoldInd",
-    "description": "Right BA45_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003918",
-    "structure_id": 403,
-    "label": "Right BA45_exvivo.thresh CurvInd",
-    "description": "Right BA45_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003919",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh NumVert",
-    "description": "Right V1_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003920",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right V1_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003921",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right V1_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003922",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh ThickAvg (mm)",
-    "description": "Right V1_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003923",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh ThickStd (mm)",
-    "description": "Right V1_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003924",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right V1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003925",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right V1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003926",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh FoldInd",
-    "description": "Right V1_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003927",
-    "structure_id": 400,
-    "label": "Right V1_exvivo.thresh CurvInd",
-    "description": "Right V1_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003928",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh NumVert",
-    "description": "Right V2_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003929",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right V2_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003930",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right V2_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003931",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh ThickAvg (mm)",
-    "description": "Right V2_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003932",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh ThickStd (mm)",
-    "description": "Right V2_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003933",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right V2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003934",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right V2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003935",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh FoldInd",
-    "description": "Right V2_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003936",
-    "structure_id": 401,
-    "label": "Right V2_exvivo.thresh CurvInd",
-    "description": "Right V2_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003937",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh NumVert",
-    "description": "Right MT_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003938",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right MT_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003939",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right MT_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003940",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh ThickAvg (mm)",
-    "description": "Right MT_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003941",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh ThickStd (mm)",
-    "description": "Right MT_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003942",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right MT_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003943",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right MT_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003944",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh FoldInd",
-    "description": "Right MT_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003945",
-    "structure_id": 414,
-    "label": "Right MT_exvivo.thresh CurvInd",
-    "description": "Right MT_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003946",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh NumVert",
-    "description": "Right perirhinal_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003947",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right perirhinal_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003948",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right perirhinal_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003949",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh ThickAvg (mm)",
-    "description": "Right perirhinal_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003950",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh ThickStd (mm)",
-    "description": "Right perirhinal_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003951",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right perirhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003952",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right perirhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003953",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh FoldInd",
-    "description": "Right perirhinal_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003954",
-    "structure_id": null,
-    "label": "Right perirhinal_exvivo.thresh CurvInd",
-    "description": "Right perirhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003955",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh NumVert",
-    "description": "Right entorhinal_exvivo.thresh Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003956",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh SurfArea (mm^2)",
-    "description": "Right entorhinal_exvivo.thresh Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003957",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh GrayVol (mm^3)",
-    "description": "Right entorhinal_exvivo.thresh Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003958",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh ThickAvg (mm)",
-    "description": "Right entorhinal_exvivo.thresh Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003959",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh ThickStd (mm)",
-    "description": "Right entorhinal_exvivo.thresh Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003960",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh MeanCurv (mm^-1)",
-    "description": "Right entorhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003961",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh GausCurv (mm^-2)",
-    "description": "Right entorhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003962",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh FoldInd",
-    "description": "Right entorhinal_exvivo.thresh Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003963",
-    "structure_id": null,
-    "label": "Right entorhinal_exvivo.thresh CurvInd",
-    "description": "Right entorhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003964",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin NumVert",
-    "description": "Right G_and_S_frontomargin Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003965",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin SurfArea (mm^2)",
-    "description": "Right G_and_S_frontomargin Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003966",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin GrayVol (mm^3)",
-    "description": "Right G_and_S_frontomargin Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003967",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin ThickAvg (mm)",
-    "description": "Right G_and_S_frontomargin Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003968",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin ThickStd (mm)",
-    "description": "Right G_and_S_frontomargin Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003969",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin MeanCurv (mm^-1)",
-    "description": "Right G_and_S_frontomargin Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003970",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin GausCurv (mm^-2)",
-    "description": "Right G_and_S_frontomargin Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003971",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin FoldInd",
-    "description": "Right G_and_S_frontomargin Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003972",
-    "structure_id": 12101,
-    "label": "Right G_and_S_frontomargin CurvInd",
-    "description": "Right G_and_S_frontomargin Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003973",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf NumVert",
-    "description": "Right G_and_S_occipital_inf Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003974",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf SurfArea (mm^2)",
-    "description": "Right G_and_S_occipital_inf Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003975",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf GrayVol (mm^3)",
-    "description": "Right G_and_S_occipital_inf Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003976",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf ThickAvg (mm)",
-    "description": "Right G_and_S_occipital_inf Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003977",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf ThickStd (mm)",
-    "description": "Right G_and_S_occipital_inf Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003978",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf MeanCurv (mm^-1)",
-    "description": "Right G_and_S_occipital_inf Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003979",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf GausCurv (mm^-2)",
-    "description": "Right G_and_S_occipital_inf Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003980",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf FoldInd",
-    "description": "Right G_and_S_occipital_inf Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003981",
-    "structure_id": 12102,
-    "label": "Right G_and_S_occipital_inf CurvInd",
-    "description": "Right G_and_S_occipital_inf Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003982",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral NumVert",
-    "description": "Right G_and_S_paracentral Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003983",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral SurfArea (mm^2)",
-    "description": "Right G_and_S_paracentral Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003984",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral GrayVol (mm^3)",
-    "description": "Right G_and_S_paracentral Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003985",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral ThickAvg (mm)",
-    "description": "Right G_and_S_paracentral Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003986",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral ThickStd (mm)",
-    "description": "Right G_and_S_paracentral Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003987",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral MeanCurv (mm^-1)",
-    "description": "Right G_and_S_paracentral Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003988",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral GausCurv (mm^-2)",
-    "description": "Right G_and_S_paracentral Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003989",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral FoldInd",
-    "description": "Right G_and_S_paracentral Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_paracentral', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003990",
-    "structure_id": 12103,
-    "label": "Right G_and_S_paracentral CurvInd",
-    "description": "Right G_and_S_paracentral Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "003991",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral NumVert",
-    "description": "Right G_and_S_subcentral Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "003992",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral SurfArea (mm^2)",
-    "description": "Right G_and_S_subcentral Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "003993",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral GrayVol (mm^3)",
-    "description": "Right G_and_S_subcentral Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "003994",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral ThickAvg (mm)",
-    "description": "Right G_and_S_subcentral Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "003995",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral ThickStd (mm)",
-    "description": "Right G_and_S_subcentral Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "003996",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral MeanCurv (mm^-1)",
-    "description": "Right G_and_S_subcentral Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "003997",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral GausCurv (mm^-2)",
-    "description": "Right G_and_S_subcentral Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "003998",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral FoldInd",
-    "description": "Right G_and_S_subcentral Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_subcentral', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "003999",
-    "structure_id": 12104,
-    "label": "Right G_and_S_subcentral CurvInd",
-    "description": "Right G_and_S_subcentral Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004000",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol NumVert",
-    "description": "Right G_and_S_transv_frontopol Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004001",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol SurfArea (mm^2)",
-    "description": "Right G_and_S_transv_frontopol Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004002",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol GrayVol (mm^3)",
-    "description": "Right G_and_S_transv_frontopol Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004003",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol ThickAvg (mm)",
-    "description": "Right G_and_S_transv_frontopol Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004004",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol ThickStd (mm)",
-    "description": "Right G_and_S_transv_frontopol Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004005",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol MeanCurv (mm^-1)",
-    "description": "Right G_and_S_transv_frontopol Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004006",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol GausCurv (mm^-2)",
-    "description": "Right G_and_S_transv_frontopol Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004007",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol FoldInd",
-    "description": "Right G_and_S_transv_frontopol Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004008",
-    "structure_id": 12105,
-    "label": "Right G_and_S_transv_frontopol CurvInd",
-    "description": "Right G_and_S_transv_frontopol Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004009",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant NumVert",
-    "description": "Right G_and_S_cingul-Ant Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004010",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant SurfArea (mm^2)",
-    "description": "Right G_and_S_cingul-Ant Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004011",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant GrayVol (mm^3)",
-    "description": "Right G_and_S_cingul-Ant Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004012",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant ThickAvg (mm)",
-    "description": "Right G_and_S_cingul-Ant Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004013",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant ThickStd (mm)",
-    "description": "Right G_and_S_cingul-Ant Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004014",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant MeanCurv (mm^-1)",
-    "description": "Right G_and_S_cingul-Ant Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004015",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant GausCurv (mm^-2)",
-    "description": "Right G_and_S_cingul-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004016",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant FoldInd",
-    "description": "Right G_and_S_cingul-Ant Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004017",
-    "structure_id": 12106,
-    "label": "Right G_and_S_cingul-Ant CurvInd",
-    "description": "Right G_and_S_cingul-Ant Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004018",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant NumVert",
-    "description": "Right G_and_S_cingul-Mid-Ant Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004019",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant SurfArea (mm^2)",
-    "description": "Right G_and_S_cingul-Mid-Ant Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004020",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant GrayVol (mm^3)",
-    "description": "Right G_and_S_cingul-Mid-Ant Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004021",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant ThickAvg (mm)",
-    "description": "Right G_and_S_cingul-Mid-Ant Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004022",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant ThickStd (mm)",
-    "description": "Right G_and_S_cingul-Mid-Ant Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004023",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant MeanCurv (mm^-1)",
-    "description": "Right G_and_S_cingul-Mid-Ant Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004024",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant GausCurv (mm^-2)",
-    "description": "Right G_and_S_cingul-Mid-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004025",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant FoldInd",
-    "description": "Right G_and_S_cingul-Mid-Ant Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004026",
-    "structure_id": 12107,
-    "label": "Right G_and_S_cingul-Mid-Ant CurvInd",
-    "description": "Right G_and_S_cingul-Mid-Ant Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004027",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post NumVert",
-    "description": "Right G_and_S_cingul-Mid-Post Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004028",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post SurfArea (mm^2)",
-    "description": "Right G_and_S_cingul-Mid-Post Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004029",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post GrayVol (mm^3)",
-    "description": "Right G_and_S_cingul-Mid-Post Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004030",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post ThickAvg (mm)",
-    "description": "Right G_and_S_cingul-Mid-Post Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004031",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post ThickStd (mm)",
-    "description": "Right G_and_S_cingul-Mid-Post Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004032",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post MeanCurv (mm^-1)",
-    "description": "Right G_and_S_cingul-Mid-Post Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004033",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post GausCurv (mm^-2)",
-    "description": "Right G_and_S_cingul-Mid-Post Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004034",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post FoldInd",
-    "description": "Right G_and_S_cingul-Mid-Post Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004035",
-    "structure_id": 12108,
-    "label": "Right G_and_S_cingul-Mid-Post CurvInd",
-    "description": "Right G_and_S_cingul-Mid-Post Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004036",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins NumVert",
-    "description": "Right G_Ins_lg_and_S_cent_ins Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004037",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins SurfArea (mm^2)",
-    "description": "Right G_Ins_lg_and_S_cent_ins Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004038",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins GrayVol (mm^3)",
-    "description": "Right G_Ins_lg_and_S_cent_ins Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004039",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins ThickAvg (mm)",
-    "description": "Right G_Ins_lg_and_S_cent_ins Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004040",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins ThickStd (mm)",
-    "description": "Right G_Ins_lg_and_S_cent_ins Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004041",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins MeanCurv (mm^-1)",
-    "description": "Right G_Ins_lg_and_S_cent_ins Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004042",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins GausCurv (mm^-2)",
-    "description": "Right G_Ins_lg_and_S_cent_ins Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004043",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins FoldInd",
-    "description": "Right G_Ins_lg_and_S_cent_ins Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004044",
-    "structure_id": 12117,
-    "label": "Right G_Ins_lg_and_S_cent_ins CurvInd",
-    "description": "Right G_Ins_lg_and_S_cent_ins Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004045",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans NumVert",
-    "description": "Right S_intrapariet_and_P_trans Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004046",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans SurfArea (mm^2)",
-    "description": "Right S_intrapariet_and_P_trans Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004047",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans GrayVol (mm^3)",
-    "description": "Right S_intrapariet_and_P_trans Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004048",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans ThickAvg (mm)",
-    "description": "Right S_intrapariet_and_P_trans Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004049",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans ThickStd (mm)",
-    "description": "Right S_intrapariet_and_P_trans Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004050",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans MeanCurv (mm^-1)",
-    "description": "Right S_intrapariet_and_P_trans Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004051",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans GausCurv (mm^-2)",
-    "description": "Right S_intrapariet_and_P_trans Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004052",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans FoldInd",
-    "description": "Right S_intrapariet_and_P_trans Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004053",
-    "structure_id": 12157,
-    "label": "Right S_intrapariet_and_P_trans CurvInd",
-    "description": "Right S_intrapariet_and_P_trans Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004054",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus NumVert",
-    "description": "Right S_oc_middle_and_Lunatus Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004055",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus SurfArea (mm^2)",
-    "description": "Right S_oc_middle_and_Lunatus Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004056",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus GrayVol (mm^3)",
-    "description": "Right S_oc_middle_and_Lunatus Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004057",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus ThickAvg (mm)",
-    "description": "Right S_oc_middle_and_Lunatus Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004058",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus ThickStd (mm)",
-    "description": "Right S_oc_middle_and_Lunatus Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004059",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus MeanCurv (mm^-1)",
-    "description": "Right S_oc_middle_and_Lunatus Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004060",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus GausCurv (mm^-2)",
-    "description": "Right S_oc_middle_and_Lunatus Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004061",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus FoldInd",
-    "description": "Right S_oc_middle_and_Lunatus Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004062",
-    "structure_id": 12158,
-    "label": "Right S_oc_middle_and_Lunatus CurvInd",
-    "description": "Right S_oc_middle_and_Lunatus Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004063",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal NumVert",
-    "description": "Right S_oc_sup_and_transversal Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004064",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal SurfArea (mm^2)",
-    "description": "Right S_oc_sup_and_transversal Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004065",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal GrayVol (mm^3)",
-    "description": "Right S_oc_sup_and_transversal Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004066",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal ThickAvg (mm)",
-    "description": "Right S_oc_sup_and_transversal Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004067",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal ThickStd (mm)",
-    "description": "Right S_oc_sup_and_transversal Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004068",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal MeanCurv (mm^-1)",
-    "description": "Right S_oc_sup_and_transversal Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004069",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal GausCurv (mm^-2)",
-    "description": "Right S_oc_sup_and_transversal Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004070",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal FoldInd",
-    "description": "Right S_oc_sup_and_transversal Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004071",
-    "structure_id": 12159,
-    "label": "Right S_oc_sup_and_transversal CurvInd",
-    "description": "Right S_oc_sup_and_transversal Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='NumVert', unit='unitless')": {
-    "id": "004072",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual NumVert",
-    "description": "Right S_oc-temp_med_and_Lingual Number of Vertices (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='SurfArea', unit='mm^2')": {
-    "id": "004073",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual SurfArea (mm^2)",
-    "description": "Right S_oc-temp_med_and_Lingual Surface Area (mm^2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='GrayVol', unit='mm^3')": {
-    "id": "004074",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual GrayVol (mm^3)",
-    "description": "Right S_oc-temp_med_and_Lingual Gray Matter Volume (mm^3)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='ThickAvg', unit='mm')": {
-    "id": "004075",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual ThickAvg (mm)",
-    "description": "Right S_oc-temp_med_and_Lingual Average Thickness (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='ThickStd', unit='mm')": {
-    "id": "004076",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual ThickStd (mm)",
-    "description": "Right S_oc-temp_med_and_Lingual Thickness StdDev (mm)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
-    "id": "004077",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual MeanCurv (mm^-1)",
-    "description": "Right S_oc-temp_med_and_Lingual Integrated Rectified Mean Curvature (mm^-1)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='GausCurv', unit='mm^-2')": {
-    "id": "004078",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual GausCurv (mm^-2)",
-    "description": "Right S_oc-temp_med_and_Lingual Integrated Rectified Gaussian Curvature (mm^-2)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='FoldInd', unit='unitless')": {
-    "id": "004079",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual FoldInd",
-    "description": "Right S_oc-temp_med_and_Lingual Folding Index (unitless)",
-    "key_source": "Table"
-  },
-  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='CurvInd', unit='unitless')": {
-    "id": "004080",
-    "structure_id": 12162,
-    "label": "Right S_oc-temp_med_and_Lingual CurvInd",
-    "description": "Right S_oc-temp_med_and_Lingual Intrinsic Curvature Index (unitless)",
-    "key_source": "Table"
-  },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='NVoxels', unit='unitless')": {
-    "id": "004081",
+    "id": "003594",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus NVoxels",
     "description": "Left-Transverse-Sinus Number of Voxels (unitless)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Volume_mm3', unit='mm^3')": {
-    "id": "004082",
+    "id": "003595",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus Volume_mm3 (mm^3)",
     "description": "Left-Transverse-Sinus Volume (mm^3)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Mean', unit='unknown')": {
-    "id": "004083",
+    "id": "003596",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus Mean (unknown)",
     "description": "Left-Transverse-Sinus Intensity Mean (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='StdDev', unit='unknown')": {
-    "id": "004084",
+    "id": "003597",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus StdDev (unknown)",
     "description": "Left-Transverse-Sinus Intensity StdDev (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Min', unit='unknown')": {
-    "id": "004085",
+    "id": "003598",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus Min (unknown)",
     "description": "Left-Transverse-Sinus Intensity Min (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738266",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Max', unit='unknown')": {
-    "id": "004086",
+    "id": "003599",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus Max (unknown)",
     "description": "Left-Transverse-Sinus Intensity Max (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738267",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Left-Transverse-Sinus', hemi='Left', measure='Range', unit='unknown')": {
-    "id": "004087",
+    "id": "003600",
     "structure_id": 6111,
     "label": "Left-Transverse-Sinus Range (unknown)",
     "description": "Left-Transverse-Sinus Intensity Range (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738268",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='NVoxels', unit='unitless')": {
-    "id": "004088",
+    "id": "003601",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus NVoxels",
     "description": "Right-Transverse-Sinus Number of Voxels (unitless)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Volume_mm3', unit='mm^3')": {
-    "id": "004089",
+    "id": "003602",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus Volume_mm3 (mm^3)",
     "description": "Right-Transverse-Sinus Volume (mm^3)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Mean', unit='unknown')": {
-    "id": "004090",
+    "id": "003603",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus Mean (unknown)",
     "description": "Right-Transverse-Sinus Intensity Mean (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='StdDev', unit='unknown')": {
-    "id": "004091",
+    "id": "003604",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus StdDev (unknown)",
     "description": "Right-Transverse-Sinus Intensity StdDev (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Min', unit='unknown')": {
-    "id": "004092",
+    "id": "003605",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus Min (unknown)",
     "description": "Right-Transverse-Sinus Intensity Min (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738266",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Max', unit='unknown')": {
-    "id": "004093",
+    "id": "003606",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus Max (unknown)",
     "description": "Right-Transverse-Sinus Intensity Max (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738267",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Right-Transverse-Sinus', hemi='Right', measure='Range', unit='unknown')": {
-    "id": "004094",
+    "id": "003607",
     "structure_id": 6112,
     "label": "Right-Transverse-Sinus Range (unknown)",
     "description": "Right-Transverse-Sinus Intensity Range (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738268",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='NVoxels', unit='unitless')": {
-    "id": "004095",
+    "id": "003608",
     "structure_id": 6115,
     "label": "Straight-Sinus NVoxels",
     "description": "Straight-Sinus Number of Voxels (unitless)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='Volume_mm3', unit='mm^3')": {
-    "id": "004096",
+    "id": "003609",
     "structure_id": 6115,
     "label": "Straight-Sinus Volume_mm3 (mm^3)",
     "description": "Straight-Sinus Volume (mm^3)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='Mean', unit='unknown')": {
-    "id": "004097",
+    "id": "003610",
     "structure_id": 6115,
     "label": "Straight-Sinus Mean (unknown)",
     "description": "Straight-Sinus Intensity Mean (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='StdDev', unit='unknown')": {
-    "id": "004098",
+    "id": "003611",
     "structure_id": 6115,
     "label": "Straight-Sinus StdDev (unknown)",
     "description": "Straight-Sinus Intensity StdDev (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='Min', unit='unknown')": {
-    "id": "004099",
+    "id": "003612",
     "structure_id": 6115,
     "label": "Straight-Sinus Min (unknown)",
     "description": "Straight-Sinus Intensity Min (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738266",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='Max', unit='unknown')": {
-    "id": "004100",
+    "id": "003613",
     "structure_id": 6115,
     "label": "Straight-Sinus Max (unknown)",
     "description": "Straight-Sinus Intensity Max (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738267",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Straight-Sinus', hemi=None, measure='Range', unit='unknown')": {
-    "id": "004101",
+    "id": "003614",
     "structure_id": 6115,
     "label": "Straight-Sinus Range (unknown)",
     "description": "Straight-Sinus Intensity Range (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738268",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='NVoxels', unit='unitless')": {
-    "id": "004102",
+    "id": "003615",
     "structure_id": 6116,
     "label": "Superior-Sinus-P NVoxels",
     "description": "Superior-Sinus-P Number of Voxels (unitless)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='Volume_mm3', unit='mm^3')": {
-    "id": "004103",
+    "id": "003616",
     "structure_id": 6116,
     "label": "Superior-Sinus-P Volume_mm3 (mm^3)",
     "description": "Superior-Sinus-P Volume (mm^3)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='Mean', unit='unknown')": {
-    "id": "004104",
+    "id": "003617",
     "structure_id": 6116,
     "label": "Superior-Sinus-P Mean (unknown)",
     "description": "Superior-Sinus-P Intensity Mean (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='StdDev', unit='unknown')": {
-    "id": "004105",
+    "id": "003618",
     "structure_id": 6116,
     "label": "Superior-Sinus-P StdDev (unknown)",
     "description": "Superior-Sinus-P Intensity StdDev (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='Min', unit='unknown')": {
-    "id": "004106",
+    "id": "003619",
     "structure_id": 6116,
     "label": "Superior-Sinus-P Min (unknown)",
     "description": "Superior-Sinus-P Intensity Min (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738266",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='Max', unit='unknown')": {
-    "id": "004107",
+    "id": "003620",
     "structure_id": 6116,
     "label": "Superior-Sinus-P Max (unknown)",
     "description": "Superior-Sinus-P Intensity Max (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738267",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-P', hemi=None, measure='Range', unit='unknown')": {
-    "id": "004108",
+    "id": "003621",
     "structure_id": 6116,
     "label": "Superior-Sinus-P Range (unknown)",
     "description": "Superior-Sinus-P Intensity Range (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738268",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='NVoxels', unit='unitless')": {
-    "id": "004109",
+    "id": "003622",
     "structure_id": 6117,
     "label": "Superior-Sinus-D NVoxels",
     "description": "Superior-Sinus-D Number of Voxels (unitless)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='Volume_mm3', unit='mm^3')": {
-    "id": "004110",
+    "id": "003623",
     "structure_id": 6117,
     "label": "Superior-Sinus-D Volume_mm3 (mm^3)",
     "description": "Superior-Sinus-D Volume (mm^3)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='Mean', unit='unknown')": {
-    "id": "004111",
+    "id": "003624",
     "structure_id": 6117,
     "label": "Superior-Sinus-D Mean (unknown)",
     "description": "Superior-Sinus-D Intensity Mean (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='StdDev', unit='unknown')": {
-    "id": "004112",
+    "id": "003625",
     "structure_id": 6117,
     "label": "Superior-Sinus-D StdDev (unknown)",
     "description": "Superior-Sinus-D Intensity StdDev (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='Min', unit='unknown')": {
-    "id": "004113",
+    "id": "003626",
     "structure_id": 6117,
     "label": "Superior-Sinus-D Min (unknown)",
     "description": "Superior-Sinus-D Intensity Min (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738266",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='Max', unit='unknown')": {
-    "id": "004114",
+    "id": "003627",
     "structure_id": 6117,
     "label": "Superior-Sinus-D Max (unknown)",
     "description": "Superior-Sinus-D Intensity Max (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738267",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
   },
   "FS(structure='Superior-Sinus-D', hemi=None, measure='Range', unit='unknown')": {
-    "id": "004115",
+    "id": "003628",
     "structure_id": 6117,
     "label": "Superior-Sinus-D Range (unknown)",
     "description": "Superior-Sinus-D Intensity Range (unknown)",
-    "key_source": "Table"
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738268",
+    "fsunit": "unknown",
+    "hasUnit": "fs:unknown",
+    "measureOf": "http://uri.interlex.org/base/ilx_0738276"
+  },
+  "FS(structure='wm-lh-entorhinal', hemi=None, measure='NVoxels', unit='unknown')": {
+    "id": "003629",
+    "structure_id": 3006,
+    "label": "wm-lh-entorhinal NVoxels (unknown)",
+    "description": "wm-lh-entorhinal NVoxels (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-lh-entorhinal', hemi=None, measure='Volume_mm3', unit='unknown')": {
+    "id": "003630",
+    "structure_id": 3006,
+    "label": "wm-lh-entorhinal Volume_mm3 (unknown)",
+    "description": "wm-lh-entorhinal Volume_mm3 (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-lh-gyrus-ambiens', hemi=None, measure='NVoxels', unit='unknown')": {
+    "id": "003631",
+    "structure_id": 3201,
+    "label": "wm-lh-gyrus-ambiens NVoxels (unknown)",
+    "description": "wm-lh-gyrus-ambiens NVoxels (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-lh-gyrus-ambiens', hemi=None, measure='Volume_mm3', unit='unknown')": {
+    "id": "003632",
+    "structure_id": 3201,
+    "label": "wm-lh-gyrus-ambiens Volume_mm3 (unknown)",
+    "description": "wm-lh-gyrus-ambiens Volume_mm3 (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-rh-entorhinal', hemi=None, measure='NVoxels', unit='unknown')": {
+    "id": "003633",
+    "structure_id": 4006,
+    "label": "wm-rh-entorhinal NVoxels (unknown)",
+    "description": "wm-rh-entorhinal NVoxels (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-rh-entorhinal', hemi=None, measure='Volume_mm3', unit='unknown')": {
+    "id": "003634",
+    "structure_id": 4006,
+    "label": "wm-rh-entorhinal Volume_mm3 (unknown)",
+    "description": "wm-rh-entorhinal Volume_mm3 (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-rh-gyrus-ambiens', hemi=None, measure='NVoxels', unit='unknown')": {
+    "id": "003635",
+    "structure_id": 4201,
+    "label": "wm-rh-gyrus-ambiens NVoxels (unknown)",
+    "description": "wm-rh-gyrus-ambiens NVoxels (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "voxel",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='wm-rh-gyrus-ambiens', hemi=None, measure='Volume_mm3', unit='unknown')": {
+    "id": "003636",
+    "structure_id": 4201,
+    "label": "wm-rh-gyrus-ambiens Volume_mm3 (unknown)",
+    "description": "wm-rh-gyrus-ambiens Volume_mm3 (unknown)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='SegmentedTotalIntraCranialVol', hemi=None, measure='sTIV', unit='mm^3')": {
+    "id": "003637",
+    "structure_id": null,
+    "label": "Segmented Total Intracranial Volume (mm^3)",
+    "description": "Segmented Total Intracranial Volume (mm^3)",
+    "key_source": "Header",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "hasUnit": "mm^3",
+    "fsunit": "mm^3"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003638",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin NumVert",
+    "description": "Left G_and_S_frontomargin Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003639",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin SurfArea (mm^2)",
+    "description": "Left G_and_S_frontomargin Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003640",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin GrayVol (mm^3)",
+    "description": "Left G_and_S_frontomargin Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003641",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin ThickAvg (mm)",
+    "description": "Left G_and_S_frontomargin Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003642",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin ThickStd (mm)",
+    "description": "Left G_and_S_frontomargin Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003643",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin MeanCurv (mm^-1)",
+    "description": "Left G_and_S_frontomargin Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003644",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin GausCurv (mm^-2)",
+    "description": "Left G_and_S_frontomargin Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003645",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin FoldInd",
+    "description": "Left G_and_S_frontomargin Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003646",
+    "structure_id": 11101,
+    "label": "Left G_and_S_frontomargin CurvInd",
+    "description": "Left G_and_S_frontomargin Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003647",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf NumVert",
+    "description": "Left G_and_S_occipital_inf Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003648",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf SurfArea (mm^2)",
+    "description": "Left G_and_S_occipital_inf Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003649",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf GrayVol (mm^3)",
+    "description": "Left G_and_S_occipital_inf Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003650",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf ThickAvg (mm)",
+    "description": "Left G_and_S_occipital_inf Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003651",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf ThickStd (mm)",
+    "description": "Left G_and_S_occipital_inf Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003652",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf MeanCurv (mm^-1)",
+    "description": "Left G_and_S_occipital_inf Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003653",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf GausCurv (mm^-2)",
+    "description": "Left G_and_S_occipital_inf Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003654",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf FoldInd",
+    "description": "Left G_and_S_occipital_inf Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003655",
+    "structure_id": 11102,
+    "label": "Left G_and_S_occipital_inf CurvInd",
+    "description": "Left G_and_S_occipital_inf Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003656",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral NumVert",
+    "description": "Left G_and_S_paracentral Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003657",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral SurfArea (mm^2)",
+    "description": "Left G_and_S_paracentral Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003658",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral GrayVol (mm^3)",
+    "description": "Left G_and_S_paracentral Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003659",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral ThickAvg (mm)",
+    "description": "Left G_and_S_paracentral Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003660",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral ThickStd (mm)",
+    "description": "Left G_and_S_paracentral Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003661",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral MeanCurv (mm^-1)",
+    "description": "Left G_and_S_paracentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003662",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral GausCurv (mm^-2)",
+    "description": "Left G_and_S_paracentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003663",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral FoldInd",
+    "description": "Left G_and_S_paracentral Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003664",
+    "structure_id": 11103,
+    "label": "Left G_and_S_paracentral CurvInd",
+    "description": "Left G_and_S_paracentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003665",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral NumVert",
+    "description": "Left G_and_S_subcentral Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003666",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral SurfArea (mm^2)",
+    "description": "Left G_and_S_subcentral Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003667",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral GrayVol (mm^3)",
+    "description": "Left G_and_S_subcentral Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003668",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral ThickAvg (mm)",
+    "description": "Left G_and_S_subcentral Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003669",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral ThickStd (mm)",
+    "description": "Left G_and_S_subcentral Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003670",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral MeanCurv (mm^-1)",
+    "description": "Left G_and_S_subcentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003671",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral GausCurv (mm^-2)",
+    "description": "Left G_and_S_subcentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003672",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral FoldInd",
+    "description": "Left G_and_S_subcentral Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003673",
+    "structure_id": 11104,
+    "label": "Left G_and_S_subcentral CurvInd",
+    "description": "Left G_and_S_subcentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003674",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol NumVert",
+    "description": "Left G_and_S_transv_frontopol Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003675",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol SurfArea (mm^2)",
+    "description": "Left G_and_S_transv_frontopol Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003676",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol GrayVol (mm^3)",
+    "description": "Left G_and_S_transv_frontopol Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003677",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol ThickAvg (mm)",
+    "description": "Left G_and_S_transv_frontopol Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003678",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol ThickStd (mm)",
+    "description": "Left G_and_S_transv_frontopol Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003679",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol MeanCurv (mm^-1)",
+    "description": "Left G_and_S_transv_frontopol Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003680",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol GausCurv (mm^-2)",
+    "description": "Left G_and_S_transv_frontopol Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003681",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol FoldInd",
+    "description": "Left G_and_S_transv_frontopol Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003682",
+    "structure_id": 11105,
+    "label": "Left G_and_S_transv_frontopol CurvInd",
+    "description": "Left G_and_S_transv_frontopol Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003683",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant NumVert",
+    "description": "Left G_and_S_cingul-Ant Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003684",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant SurfArea (mm^2)",
+    "description": "Left G_and_S_cingul-Ant Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003685",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant GrayVol (mm^3)",
+    "description": "Left G_and_S_cingul-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003686",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant ThickAvg (mm)",
+    "description": "Left G_and_S_cingul-Ant Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003687",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant ThickStd (mm)",
+    "description": "Left G_and_S_cingul-Ant Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003688",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant MeanCurv (mm^-1)",
+    "description": "Left G_and_S_cingul-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003689",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant GausCurv (mm^-2)",
+    "description": "Left G_and_S_cingul-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003690",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant FoldInd",
+    "description": "Left G_and_S_cingul-Ant Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003691",
+    "structure_id": 11106,
+    "label": "Left G_and_S_cingul-Ant CurvInd",
+    "description": "Left G_and_S_cingul-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003692",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant NumVert",
+    "description": "Left G_and_S_cingul-Mid-Ant Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003693",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant SurfArea (mm^2)",
+    "description": "Left G_and_S_cingul-Mid-Ant Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003694",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant GrayVol (mm^3)",
+    "description": "Left G_and_S_cingul-Mid-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003695",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant ThickAvg (mm)",
+    "description": "Left G_and_S_cingul-Mid-Ant Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003696",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant ThickStd (mm)",
+    "description": "Left G_and_S_cingul-Mid-Ant Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003697",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant MeanCurv (mm^-1)",
+    "description": "Left G_and_S_cingul-Mid-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003698",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant GausCurv (mm^-2)",
+    "description": "Left G_and_S_cingul-Mid-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003699",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant FoldInd",
+    "description": "Left G_and_S_cingul-Mid-Ant Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003700",
+    "structure_id": 11107,
+    "label": "Left G_and_S_cingul-Mid-Ant CurvInd",
+    "description": "Left G_and_S_cingul-Mid-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003701",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post NumVert",
+    "description": "Left G_and_S_cingul-Mid-Post Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003702",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post SurfArea (mm^2)",
+    "description": "Left G_and_S_cingul-Mid-Post Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003703",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post GrayVol (mm^3)",
+    "description": "Left G_and_S_cingul-Mid-Post Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003704",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post ThickAvg (mm)",
+    "description": "Left G_and_S_cingul-Mid-Post Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003705",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post ThickStd (mm)",
+    "description": "Left G_and_S_cingul-Mid-Post Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003706",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post MeanCurv (mm^-1)",
+    "description": "Left G_and_S_cingul-Mid-Post Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003707",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post GausCurv (mm^-2)",
+    "description": "Left G_and_S_cingul-Mid-Post Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003708",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post FoldInd",
+    "description": "Left G_and_S_cingul-Mid-Post Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003709",
+    "structure_id": 11108,
+    "label": "Left G_and_S_cingul-Mid-Post CurvInd",
+    "description": "Left G_and_S_cingul-Mid-Post Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003710",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins NumVert",
+    "description": "Left G_Ins_lg_and_S_cent_ins Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003711",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins SurfArea (mm^2)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003712",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins GrayVol (mm^3)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003713",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins ThickAvg (mm)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003714",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins ThickStd (mm)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003715",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins MeanCurv (mm^-1)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003716",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins GausCurv (mm^-2)",
+    "description": "Left G_Ins_lg_and_S_cent_ins Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003717",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins FoldInd",
+    "description": "Left G_Ins_lg_and_S_cent_ins Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003718",
+    "structure_id": 11117,
+    "label": "Left G_Ins_lg_and_S_cent_ins CurvInd",
+    "description": "Left G_Ins_lg_and_S_cent_ins Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003719",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans NumVert",
+    "description": "Left S_intrapariet_and_P_trans Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003720",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans SurfArea (mm^2)",
+    "description": "Left S_intrapariet_and_P_trans Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003721",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans GrayVol (mm^3)",
+    "description": "Left S_intrapariet_and_P_trans Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003722",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans ThickAvg (mm)",
+    "description": "Left S_intrapariet_and_P_trans Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003723",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans ThickStd (mm)",
+    "description": "Left S_intrapariet_and_P_trans Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003724",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans MeanCurv (mm^-1)",
+    "description": "Left S_intrapariet_and_P_trans Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003725",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans GausCurv (mm^-2)",
+    "description": "Left S_intrapariet_and_P_trans Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003726",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans FoldInd",
+    "description": "Left S_intrapariet_and_P_trans Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003727",
+    "structure_id": 11157,
+    "label": "Left S_intrapariet_and_P_trans CurvInd",
+    "description": "Left S_intrapariet_and_P_trans Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003728",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus NumVert",
+    "description": "Left S_oc_middle_and_Lunatus Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003729",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus SurfArea (mm^2)",
+    "description": "Left S_oc_middle_and_Lunatus Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003730",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus GrayVol (mm^3)",
+    "description": "Left S_oc_middle_and_Lunatus Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003731",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus ThickAvg (mm)",
+    "description": "Left S_oc_middle_and_Lunatus Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003732",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus ThickStd (mm)",
+    "description": "Left S_oc_middle_and_Lunatus Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003733",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus MeanCurv (mm^-1)",
+    "description": "Left S_oc_middle_and_Lunatus Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003734",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus GausCurv (mm^-2)",
+    "description": "Left S_oc_middle_and_Lunatus Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003735",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus FoldInd",
+    "description": "Left S_oc_middle_and_Lunatus Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003736",
+    "structure_id": 11158,
+    "label": "Left S_oc_middle_and_Lunatus CurvInd",
+    "description": "Left S_oc_middle_and_Lunatus Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003737",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal NumVert",
+    "description": "Left S_oc_sup_and_transversal Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003738",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal SurfArea (mm^2)",
+    "description": "Left S_oc_sup_and_transversal Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003739",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal GrayVol (mm^3)",
+    "description": "Left S_oc_sup_and_transversal Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003740",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal ThickAvg (mm)",
+    "description": "Left S_oc_sup_and_transversal Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003741",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal ThickStd (mm)",
+    "description": "Left S_oc_sup_and_transversal Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003742",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal MeanCurv (mm^-1)",
+    "description": "Left S_oc_sup_and_transversal Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003743",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal GausCurv (mm^-2)",
+    "description": "Left S_oc_sup_and_transversal Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003744",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal FoldInd",
+    "description": "Left S_oc_sup_and_transversal Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003745",
+    "structure_id": 11159,
+    "label": "Left S_oc_sup_and_transversal CurvInd",
+    "description": "Left S_oc_sup_and_transversal Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003746",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual NumVert",
+    "description": "Left S_oc-temp_med_and_Lingual Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003747",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual SurfArea (mm^2)",
+    "description": "Left S_oc-temp_med_and_Lingual Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003748",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual GrayVol (mm^3)",
+    "description": "Left S_oc-temp_med_and_Lingual Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003749",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual ThickAvg (mm)",
+    "description": "Left S_oc-temp_med_and_Lingual Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003750",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual ThickStd (mm)",
+    "description": "Left S_oc-temp_med_and_Lingual Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003751",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual MeanCurv (mm^-1)",
+    "description": "Left S_oc-temp_med_and_Lingual Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003752",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual GausCurv (mm^-2)",
+    "description": "Left S_oc-temp_med_and_Lingual Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003753",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual FoldInd",
+    "description": "Left S_oc-temp_med_and_Lingual Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003754",
+    "structure_id": 11162,
+    "label": "Left S_oc-temp_med_and_Lingual CurvInd",
+    "description": "Left S_oc-temp_med_and_Lingual Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003755",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin NumVert",
+    "description": "Right G_and_S_frontomargin Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003756",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin SurfArea (mm^2)",
+    "description": "Right G_and_S_frontomargin Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003757",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin GrayVol (mm^3)",
+    "description": "Right G_and_S_frontomargin Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003758",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin ThickAvg (mm)",
+    "description": "Right G_and_S_frontomargin Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003759",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin ThickStd (mm)",
+    "description": "Right G_and_S_frontomargin Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003760",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin MeanCurv (mm^-1)",
+    "description": "Right G_and_S_frontomargin Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003761",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin GausCurv (mm^-2)",
+    "description": "Right G_and_S_frontomargin Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003762",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin FoldInd",
+    "description": "Right G_and_S_frontomargin Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_frontomargin', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003763",
+    "structure_id": 12101,
+    "label": "Right G_and_S_frontomargin CurvInd",
+    "description": "Right G_and_S_frontomargin Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003764",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf NumVert",
+    "description": "Right G_and_S_occipital_inf Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003765",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf SurfArea (mm^2)",
+    "description": "Right G_and_S_occipital_inf Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003766",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf GrayVol (mm^3)",
+    "description": "Right G_and_S_occipital_inf Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003767",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf ThickAvg (mm)",
+    "description": "Right G_and_S_occipital_inf Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003768",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf ThickStd (mm)",
+    "description": "Right G_and_S_occipital_inf Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003769",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf MeanCurv (mm^-1)",
+    "description": "Right G_and_S_occipital_inf Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003770",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf GausCurv (mm^-2)",
+    "description": "Right G_and_S_occipital_inf Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003771",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf FoldInd",
+    "description": "Right G_and_S_occipital_inf Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_occipital_inf', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003772",
+    "structure_id": 12102,
+    "label": "Right G_and_S_occipital_inf CurvInd",
+    "description": "Right G_and_S_occipital_inf Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003773",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral NumVert",
+    "description": "Right G_and_S_paracentral Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003774",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral SurfArea (mm^2)",
+    "description": "Right G_and_S_paracentral Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003775",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral GrayVol (mm^3)",
+    "description": "Right G_and_S_paracentral Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003776",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral ThickAvg (mm)",
+    "description": "Right G_and_S_paracentral Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003777",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral ThickStd (mm)",
+    "description": "Right G_and_S_paracentral Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003778",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral MeanCurv (mm^-1)",
+    "description": "Right G_and_S_paracentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003779",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral GausCurv (mm^-2)",
+    "description": "Right G_and_S_paracentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003780",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral FoldInd",
+    "description": "Right G_and_S_paracentral Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_paracentral', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003781",
+    "structure_id": 12103,
+    "label": "Right G_and_S_paracentral CurvInd",
+    "description": "Right G_and_S_paracentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003782",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral NumVert",
+    "description": "Right G_and_S_subcentral Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003783",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral SurfArea (mm^2)",
+    "description": "Right G_and_S_subcentral Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003784",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral GrayVol (mm^3)",
+    "description": "Right G_and_S_subcentral Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003785",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral ThickAvg (mm)",
+    "description": "Right G_and_S_subcentral Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003786",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral ThickStd (mm)",
+    "description": "Right G_and_S_subcentral Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003787",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral MeanCurv (mm^-1)",
+    "description": "Right G_and_S_subcentral Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003788",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral GausCurv (mm^-2)",
+    "description": "Right G_and_S_subcentral Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003789",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral FoldInd",
+    "description": "Right G_and_S_subcentral Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_subcentral', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003790",
+    "structure_id": 12104,
+    "label": "Right G_and_S_subcentral CurvInd",
+    "description": "Right G_and_S_subcentral Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003791",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol NumVert",
+    "description": "Right G_and_S_transv_frontopol Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003792",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol SurfArea (mm^2)",
+    "description": "Right G_and_S_transv_frontopol Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003793",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol GrayVol (mm^3)",
+    "description": "Right G_and_S_transv_frontopol Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003794",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol ThickAvg (mm)",
+    "description": "Right G_and_S_transv_frontopol Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003795",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol ThickStd (mm)",
+    "description": "Right G_and_S_transv_frontopol Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003796",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol MeanCurv (mm^-1)",
+    "description": "Right G_and_S_transv_frontopol Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003797",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol GausCurv (mm^-2)",
+    "description": "Right G_and_S_transv_frontopol Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003798",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol FoldInd",
+    "description": "Right G_and_S_transv_frontopol Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_transv_frontopol', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003799",
+    "structure_id": 12105,
+    "label": "Right G_and_S_transv_frontopol CurvInd",
+    "description": "Right G_and_S_transv_frontopol Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003800",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant NumVert",
+    "description": "Right G_and_S_cingul-Ant Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003801",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant SurfArea (mm^2)",
+    "description": "Right G_and_S_cingul-Ant Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003802",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant GrayVol (mm^3)",
+    "description": "Right G_and_S_cingul-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003803",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant ThickAvg (mm)",
+    "description": "Right G_and_S_cingul-Ant Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003804",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant ThickStd (mm)",
+    "description": "Right G_and_S_cingul-Ant Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003805",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant MeanCurv (mm^-1)",
+    "description": "Right G_and_S_cingul-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003806",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant GausCurv (mm^-2)",
+    "description": "Right G_and_S_cingul-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003807",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant FoldInd",
+    "description": "Right G_and_S_cingul-Ant Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_cingul-Ant', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003808",
+    "structure_id": 12106,
+    "label": "Right G_and_S_cingul-Ant CurvInd",
+    "description": "Right G_and_S_cingul-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003809",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant NumVert",
+    "description": "Right G_and_S_cingul-Mid-Ant Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003810",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant SurfArea (mm^2)",
+    "description": "Right G_and_S_cingul-Mid-Ant Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003811",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant GrayVol (mm^3)",
+    "description": "Right G_and_S_cingul-Mid-Ant Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003812",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant ThickAvg (mm)",
+    "description": "Right G_and_S_cingul-Mid-Ant Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003813",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant ThickStd (mm)",
+    "description": "Right G_and_S_cingul-Mid-Ant Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003814",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant MeanCurv (mm^-1)",
+    "description": "Right G_and_S_cingul-Mid-Ant Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003815",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant GausCurv (mm^-2)",
+    "description": "Right G_and_S_cingul-Mid-Ant Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003816",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant FoldInd",
+    "description": "Right G_and_S_cingul-Mid-Ant Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Ant', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003817",
+    "structure_id": 12107,
+    "label": "Right G_and_S_cingul-Mid-Ant CurvInd",
+    "description": "Right G_and_S_cingul-Mid-Ant Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003818",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post NumVert",
+    "description": "Right G_and_S_cingul-Mid-Post Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003819",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post SurfArea (mm^2)",
+    "description": "Right G_and_S_cingul-Mid-Post Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003820",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post GrayVol (mm^3)",
+    "description": "Right G_and_S_cingul-Mid-Post Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003821",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post ThickAvg (mm)",
+    "description": "Right G_and_S_cingul-Mid-Post Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003822",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post ThickStd (mm)",
+    "description": "Right G_and_S_cingul-Mid-Post Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003823",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post MeanCurv (mm^-1)",
+    "description": "Right G_and_S_cingul-Mid-Post Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003824",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post GausCurv (mm^-2)",
+    "description": "Right G_and_S_cingul-Mid-Post Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003825",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post FoldInd",
+    "description": "Right G_and_S_cingul-Mid-Post Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_and_S_cingul-Mid-Post', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003826",
+    "structure_id": 12108,
+    "label": "Right G_and_S_cingul-Mid-Post CurvInd",
+    "description": "Right G_and_S_cingul-Mid-Post Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003827",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins NumVert",
+    "description": "Right G_Ins_lg_and_S_cent_ins Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003828",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins SurfArea (mm^2)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003829",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins GrayVol (mm^3)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003830",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins ThickAvg (mm)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003831",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins ThickStd (mm)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003832",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins MeanCurv (mm^-1)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003833",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins GausCurv (mm^-2)",
+    "description": "Right G_Ins_lg_and_S_cent_ins Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003834",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins FoldInd",
+    "description": "Right G_Ins_lg_and_S_cent_ins Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='G_Ins_lg_and_S_cent_ins', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003835",
+    "structure_id": 12117,
+    "label": "Right G_Ins_lg_and_S_cent_ins CurvInd",
+    "description": "Right G_Ins_lg_and_S_cent_ins Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003836",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans NumVert",
+    "description": "Right S_intrapariet_and_P_trans Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003837",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans SurfArea (mm^2)",
+    "description": "Right S_intrapariet_and_P_trans Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003838",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans GrayVol (mm^3)",
+    "description": "Right S_intrapariet_and_P_trans Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003839",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans ThickAvg (mm)",
+    "description": "Right S_intrapariet_and_P_trans Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003840",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans ThickStd (mm)",
+    "description": "Right S_intrapariet_and_P_trans Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003841",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans MeanCurv (mm^-1)",
+    "description": "Right S_intrapariet_and_P_trans Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003842",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans GausCurv (mm^-2)",
+    "description": "Right S_intrapariet_and_P_trans Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003843",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans FoldInd",
+    "description": "Right S_intrapariet_and_P_trans Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_intrapariet_and_P_trans', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003844",
+    "structure_id": 12157,
+    "label": "Right S_intrapariet_and_P_trans CurvInd",
+    "description": "Right S_intrapariet_and_P_trans Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003845",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus NumVert",
+    "description": "Right S_oc_middle_and_Lunatus Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003846",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus SurfArea (mm^2)",
+    "description": "Right S_oc_middle_and_Lunatus Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003847",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus GrayVol (mm^3)",
+    "description": "Right S_oc_middle_and_Lunatus Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003848",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus ThickAvg (mm)",
+    "description": "Right S_oc_middle_and_Lunatus Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003849",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus ThickStd (mm)",
+    "description": "Right S_oc_middle_and_Lunatus Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003850",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus MeanCurv (mm^-1)",
+    "description": "Right S_oc_middle_and_Lunatus Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003851",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus GausCurv (mm^-2)",
+    "description": "Right S_oc_middle_and_Lunatus Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003852",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus FoldInd",
+    "description": "Right S_oc_middle_and_Lunatus Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_oc_middle_and_Lunatus', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003853",
+    "structure_id": 12158,
+    "label": "Right S_oc_middle_and_Lunatus CurvInd",
+    "description": "Right S_oc_middle_and_Lunatus Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003854",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal NumVert",
+    "description": "Right S_oc_sup_and_transversal Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003855",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal SurfArea (mm^2)",
+    "description": "Right S_oc_sup_and_transversal Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003856",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal GrayVol (mm^3)",
+    "description": "Right S_oc_sup_and_transversal Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003857",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal ThickAvg (mm)",
+    "description": "Right S_oc_sup_and_transversal Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003858",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal ThickStd (mm)",
+    "description": "Right S_oc_sup_and_transversal Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003859",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal MeanCurv (mm^-1)",
+    "description": "Right S_oc_sup_and_transversal Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003860",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal GausCurv (mm^-2)",
+    "description": "Right S_oc_sup_and_transversal Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003861",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal FoldInd",
+    "description": "Right S_oc_sup_and_transversal Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_oc_sup_and_transversal', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003862",
+    "structure_id": 12159,
+    "label": "Right S_oc_sup_and_transversal CurvInd",
+    "description": "Right S_oc_sup_and_transversal Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003863",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual NumVert",
+    "description": "Right S_oc-temp_med_and_Lingual Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003864",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual SurfArea (mm^2)",
+    "description": "Right S_oc-temp_med_and_Lingual Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "003865",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual GrayVol (mm^3)",
+    "description": "Right S_oc-temp_med_and_Lingual Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "003866",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual ThickAvg (mm)",
+    "description": "Right S_oc-temp_med_and_Lingual Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "003867",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual ThickStd (mm)",
+    "description": "Right S_oc-temp_med_and_Lingual Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003868",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual MeanCurv (mm^-1)",
+    "description": "Right S_oc-temp_med_and_Lingual Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "003869",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual GausCurv (mm^-2)",
+    "description": "Right S_oc-temp_med_and_Lingual Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "003870",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual FoldInd",
+    "description": "Right S_oc-temp_med_and_Lingual Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='S_oc-temp_med_and_Lingual', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "003871",
+    "structure_id": 12162,
+    "label": "Right S_oc-temp_med_and_Lingual CurvInd",
+    "description": "Right S_oc-temp_med_and_Lingual Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003872",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh NumVert",
+    "description": "Left BA1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003873",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003874",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003875",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003876",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003877",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003878",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003879",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh FoldInd",
+    "description": "Left BA1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003880",
+    "structure_id": 410,
+    "label": "Left BA1_exvivo.thresh CurvInd",
+    "description": "Left BA1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003881",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh NumVert",
+    "description": "Left BA2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003882",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003883",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003884",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003885",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003886",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003887",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003888",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh FoldInd",
+    "description": "Left BA2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003889",
+    "structure_id": 407,
+    "label": "Left BA2_exvivo.thresh CurvInd",
+    "description": "Left BA2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003890",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh NumVert",
+    "description": "Left BA3a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003891",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA3a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003892",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA3a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003893",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA3a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003894",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA3a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003895",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA3a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003896",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA3a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003897",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh FoldInd",
+    "description": "Left BA3a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003898",
+    "structure_id": 412,
+    "label": "Left BA3a_exvivo.thresh CurvInd",
+    "description": "Left BA3a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003899",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh NumVert",
+    "description": "Left BA3b_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003900",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA3b_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003901",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA3b_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003902",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA3b_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003903",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA3b_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003904",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA3b_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003905",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA3b_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003906",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh FoldInd",
+    "description": "Left BA3b_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003907",
+    "structure_id": 413,
+    "label": "Left BA3b_exvivo.thresh CurvInd",
+    "description": "Left BA3b_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003908",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh NumVert",
+    "description": "Left BA4a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003909",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA4a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003910",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA4a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003911",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA4a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003912",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA4a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003913",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA4a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003914",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA4a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003915",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh FoldInd",
+    "description": "Left BA4a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003916",
+    "structure_id": 404,
+    "label": "Left BA4a_exvivo.thresh CurvInd",
+    "description": "Left BA4a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003917",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh NumVert",
+    "description": "Left BA4p_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003918",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA4p_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003919",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA4p_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003920",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA4p_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003921",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA4p_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003922",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA4p_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003923",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA4p_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003924",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh FoldInd",
+    "description": "Left BA4p_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003925",
+    "structure_id": 405,
+    "label": "Left BA4p_exvivo.thresh CurvInd",
+    "description": "Left BA4p_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003926",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh NumVert",
+    "description": "Left BA6_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003927",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA6_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003928",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA6_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003929",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA6_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003930",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA6_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003931",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA6_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003932",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA6_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003933",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh FoldInd",
+    "description": "Left BA6_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003934",
+    "structure_id": 406,
+    "label": "Left BA6_exvivo.thresh CurvInd",
+    "description": "Left BA6_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003935",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh NumVert",
+    "description": "Left BA44_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003936",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA44_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003937",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA44_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003938",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA44_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003939",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA44_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003940",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA44_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003941",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA44_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003942",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh FoldInd",
+    "description": "Left BA44_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003943",
+    "structure_id": 402,
+    "label": "Left BA44_exvivo.thresh CurvInd",
+    "description": "Left BA44_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003944",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh NumVert",
+    "description": "Left BA45_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003945",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left BA45_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003946",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left BA45_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003947",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh ThickAvg (mm)",
+    "description": "Left BA45_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003948",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh ThickStd (mm)",
+    "description": "Left BA45_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003949",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left BA45_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003950",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left BA45_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003951",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh FoldInd",
+    "description": "Left BA45_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003952",
+    "structure_id": 403,
+    "label": "Left BA45_exvivo.thresh CurvInd",
+    "description": "Left BA45_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003953",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh NumVert",
+    "description": "Left V1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003954",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left V1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003955",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left V1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003956",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh ThickAvg (mm)",
+    "description": "Left V1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003957",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh ThickStd (mm)",
+    "description": "Left V1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003958",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left V1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003959",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left V1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003960",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh FoldInd",
+    "description": "Left V1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003961",
+    "structure_id": 400,
+    "label": "Left V1_exvivo.thresh CurvInd",
+    "description": "Left V1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003962",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh NumVert",
+    "description": "Left V2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003963",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left V2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003964",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left V2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003965",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh ThickAvg (mm)",
+    "description": "Left V2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003966",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh ThickStd (mm)",
+    "description": "Left V2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003967",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left V2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003968",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left V2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003969",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh FoldInd",
+    "description": "Left V2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003970",
+    "structure_id": 401,
+    "label": "Left V2_exvivo.thresh CurvInd",
+    "description": "Left V2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003971",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh NumVert",
+    "description": "Left MT_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003972",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left MT_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003973",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left MT_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003974",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh ThickAvg (mm)",
+    "description": "Left MT_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003975",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh ThickStd (mm)",
+    "description": "Left MT_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003976",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left MT_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003977",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left MT_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003978",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh FoldInd",
+    "description": "Left MT_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003979",
+    "structure_id": 414,
+    "label": "Left MT_exvivo.thresh CurvInd",
+    "description": "Left MT_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003980",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh NumVert",
+    "description": "Left perirhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003981",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left perirhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003982",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left perirhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003983",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Left perirhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003984",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Left perirhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003985",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left perirhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003986",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left perirhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003987",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh FoldInd",
+    "description": "Left perirhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003988",
+    "structure_id": null,
+    "label": "Left perirhinal_exvivo.thresh CurvInd",
+    "description": "Left perirhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='NumVert', unit='unitless')": {
+    "id": "003989",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh NumVert",
+    "description": "Left entorhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='SurfArea', unit='mm^2')": {
+    "id": "003990",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Left entorhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='GrayVol', unit='mm^3')": {
+    "id": "003991",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Left entorhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='ThickAvg', unit='mm')": {
+    "id": "003992",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Left entorhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='ThickStd', unit='mm')": {
+    "id": "003993",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Left entorhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='MeanCurv', unit='mm^-1')": {
+    "id": "003994",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Left entorhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='GausCurv', unit='mm^-2')": {
+    "id": "003995",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Left entorhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='FoldInd', unit='unitless')": {
+    "id": "003996",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh FoldInd",
+    "description": "Left entorhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Left', measure='CurvInd', unit='unitless')": {
+    "id": "003997",
+    "structure_id": null,
+    "label": "Left entorhinal_exvivo.thresh CurvInd",
+    "description": "Left entorhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "003998",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh NumVert",
+    "description": "Right BA1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "003999",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004000",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004001",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004002",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004003",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004004",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004005",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh FoldInd",
+    "description": "Right BA1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA1_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004006",
+    "structure_id": 410,
+    "label": "Right BA1_exvivo.thresh CurvInd",
+    "description": "Right BA1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004007",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh NumVert",
+    "description": "Right BA2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004008",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004009",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004010",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004011",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004012",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004013",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004014",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh FoldInd",
+    "description": "Right BA2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA2_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004015",
+    "structure_id": 407,
+    "label": "Right BA2_exvivo.thresh CurvInd",
+    "description": "Right BA2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004016",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh NumVert",
+    "description": "Right BA3a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004017",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA3a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004018",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA3a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004019",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA3a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004020",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA3a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004021",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA3a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004022",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA3a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004023",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh FoldInd",
+    "description": "Right BA3a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA3a_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004024",
+    "structure_id": 412,
+    "label": "Right BA3a_exvivo.thresh CurvInd",
+    "description": "Right BA3a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004025",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh NumVert",
+    "description": "Right BA3b_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004026",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA3b_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004027",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA3b_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004028",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA3b_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004029",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA3b_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004030",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA3b_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004031",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA3b_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004032",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh FoldInd",
+    "description": "Right BA3b_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA3b_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004033",
+    "structure_id": 413,
+    "label": "Right BA3b_exvivo.thresh CurvInd",
+    "description": "Right BA3b_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004034",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh NumVert",
+    "description": "Right BA4a_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004035",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA4a_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004036",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA4a_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004037",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA4a_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004038",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA4a_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004039",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA4a_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004040",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA4a_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004041",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh FoldInd",
+    "description": "Right BA4a_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA4a_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004042",
+    "structure_id": 404,
+    "label": "Right BA4a_exvivo.thresh CurvInd",
+    "description": "Right BA4a_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004043",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh NumVert",
+    "description": "Right BA4p_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004044",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA4p_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004045",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA4p_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004046",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA4p_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004047",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA4p_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004048",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA4p_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004049",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA4p_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004050",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh FoldInd",
+    "description": "Right BA4p_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA4p_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004051",
+    "structure_id": 405,
+    "label": "Right BA4p_exvivo.thresh CurvInd",
+    "description": "Right BA4p_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004052",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh NumVert",
+    "description": "Right BA6_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004053",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA6_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004054",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA6_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004055",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA6_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004056",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA6_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004057",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA6_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004058",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA6_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004059",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh FoldInd",
+    "description": "Right BA6_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA6_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004060",
+    "structure_id": 406,
+    "label": "Right BA6_exvivo.thresh CurvInd",
+    "description": "Right BA6_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004061",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh NumVert",
+    "description": "Right BA44_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004062",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA44_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004063",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA44_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004064",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA44_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004065",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA44_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004066",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA44_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004067",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA44_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004068",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh FoldInd",
+    "description": "Right BA44_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA44_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004069",
+    "structure_id": 402,
+    "label": "Right BA44_exvivo.thresh CurvInd",
+    "description": "Right BA44_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004070",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh NumVert",
+    "description": "Right BA45_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004071",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right BA45_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004072",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right BA45_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004073",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh ThickAvg (mm)",
+    "description": "Right BA45_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004074",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh ThickStd (mm)",
+    "description": "Right BA45_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004075",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right BA45_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004076",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right BA45_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004077",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh FoldInd",
+    "description": "Right BA45_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='BA45_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004078",
+    "structure_id": 403,
+    "label": "Right BA45_exvivo.thresh CurvInd",
+    "description": "Right BA45_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004079",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh NumVert",
+    "description": "Right V1_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004080",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right V1_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004081",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right V1_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004082",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh ThickAvg (mm)",
+    "description": "Right V1_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004083",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh ThickStd (mm)",
+    "description": "Right V1_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004084",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right V1_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004085",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right V1_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004086",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh FoldInd",
+    "description": "Right V1_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='V1_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004087",
+    "structure_id": 400,
+    "label": "Right V1_exvivo.thresh CurvInd",
+    "description": "Right V1_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004088",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh NumVert",
+    "description": "Right V2_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004089",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right V2_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004090",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right V2_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004091",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh ThickAvg (mm)",
+    "description": "Right V2_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004092",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh ThickStd (mm)",
+    "description": "Right V2_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004093",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right V2_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004094",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right V2_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004095",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh FoldInd",
+    "description": "Right V2_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='V2_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004096",
+    "structure_id": 401,
+    "label": "Right V2_exvivo.thresh CurvInd",
+    "description": "Right V2_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004097",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh NumVert",
+    "description": "Right MT_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004098",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right MT_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004099",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right MT_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004100",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh ThickAvg (mm)",
+    "description": "Right MT_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004101",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh ThickStd (mm)",
+    "description": "Right MT_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004102",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right MT_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004103",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right MT_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004104",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh FoldInd",
+    "description": "Right MT_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='MT_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004105",
+    "structure_id": 414,
+    "label": "Right MT_exvivo.thresh CurvInd",
+    "description": "Right MT_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004106",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh NumVert",
+    "description": "Right perirhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004107",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right perirhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004108",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right perirhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004109",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Right perirhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004110",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Right perirhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004111",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right perirhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004112",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right perirhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004113",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh FoldInd",
+    "description": "Right perirhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='perirhinal_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004114",
+    "structure_id": null,
+    "label": "Right perirhinal_exvivo.thresh CurvInd",
+    "description": "Right perirhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='NumVert', unit='unitless')": {
+    "id": "004115",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh NumVert",
+    "description": "Right entorhinal_exvivo.thresh Number of Vertices (unitless)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0102597",
+    "fsunit": "unitless",
+    "hasUnit": "vertex",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='SurfArea', unit='mm^2')": {
+    "id": "004116",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh SurfArea (mm^2)",
+    "description": "Right entorhinal_exvivo.thresh Surface Area (mm^2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^2",
+    "hasUnit": "mm^2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001323"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='GrayVol', unit='mm^3')": {
+    "id": "004117",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh GrayVol (mm^3)",
+    "description": "Right entorhinal_exvivo.thresh Gray Matter Volume (mm^3)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^3",
+    "hasUnit": "mm^3",
+    "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='ThickAvg', unit='mm')": {
+    "id": "004118",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh ThickAvg (mm)",
+    "description": "Right entorhinal_exvivo.thresh Average Thickness (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738264",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='ThickStd', unit='mm')": {
+    "id": "004119",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh ThickStd (mm)",
+    "description": "Right entorhinal_exvivo.thresh Thickness StdDev (mm)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738265",
+    "fsunit": "mm",
+    "hasUnit": "mm",
+    "measureOf": "http://uri.interlex.org/base/ilx_0111689"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='MeanCurv', unit='mm^-1')": {
+    "id": "004120",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh MeanCurv (mm^-1)",
+    "description": "Right entorhinal_exvivo.thresh Integrated Rectified Mean Curvature (mm^-1)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-1",
+    "hasUnit": "mm^-1",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='GausCurv', unit='mm^-2')": {
+    "id": "004121",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh GausCurv (mm^-2)",
+    "description": "Right entorhinal_exvivo.thresh Integrated Rectified Gaussian Curvature (mm^-2)",
+    "key_source": "Table",
+    "datumType": "http://uri.interlex.org/base/ilx_0738276",
+    "fsunit": "mm^-2",
+    "hasUnit": "mm^-2",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='FoldInd', unit='unitless')": {
+    "id": "004122",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh FoldInd",
+    "description": "Right entorhinal_exvivo.thresh Folding Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "fs:folding"
+  },
+  "FS(structure='entorhinal_exvivo.thresh', hemi='Right', measure='CurvInd', unit='unitless')": {
+    "id": "004123",
+    "structure_id": null,
+    "label": "Right entorhinal_exvivo.thresh CurvInd",
+    "description": "Right entorhinal_exvivo.thresh Intrinsic Curvature Index (unitless)",
+    "key_source": "Table",
+    "datumType": "http://purl.obolibrary.org/obo/NCIT_C25390",
+    "fsunit": "unitless",
+    "measureOf": "http://purl.obolibrary.org/obo/PATO_0001591"
   }
 }

--- a/segstats_jsonld/mapping_data/freesurfermap.json
+++ b/segstats_jsonld/mapping_data/freesurfermap.json
@@ -288,6 +288,12 @@
       "fsunit": "unitless",
       "hasUnit": "fs:defect-hole",
       "measureOf": "http://uri.interlex.org/base/ilx_0112559"
+    },
+    "sTIV": {
+      "datumType": "http://uri.interlex.org/base/ilx_0738276",
+      "fsunit": "mm^3",
+      "hasUnit": "mm^3",
+      "measureOf": "http://uri.interlex.org/base/ilx_0112559"
     }
   },
   "Structures": {
@@ -329,9 +335,21 @@
       ],
       "isAbout": null
     },
+    "BA1_exvivo.thresh": {
+      "fskey": [
+        "BA1_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "BA2_exvivo": {
       "fskey": [
         "BA2_exvivo"
+      ],
+      "isAbout": null
+    },
+    "BA2_exvivo.thresh": {
+      "fskey": [
+        "BA2_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -341,9 +359,21 @@
       ],
       "isAbout": null
     },
+    "BA3a_exvivo.thresh": {
+      "fskey": [
+        "BA3a_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "BA3b_exvivo": {
       "fskey": [
         "BA3b_exvivo"
+      ],
+      "isAbout": null
+    },
+    "BA3b_exvivo.thresh": {
+      "fskey": [
+        "BA3b_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -353,9 +383,21 @@
       ],
       "isAbout": null
     },
+    "BA44_exvivo.thresh": {
+      "fskey": [
+        "BA44_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "BA45_exvivo": {
       "fskey": [
         "BA45_exvivo"
+      ],
+      "isAbout": null
+    },
+    "BA45_exvivo.thresh": {
+      "fskey": [
+        "BA45_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -365,15 +407,33 @@
       ],
       "isAbout": null
     },
+    "BA4a_exvivo.thresh": {
+      "fskey": [
+        "BA4a_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "BA4p_exvivo": {
       "fskey": [
         "BA4p_exvivo"
       ],
       "isAbout": null
     },
+    "BA4p_exvivo.thresh": {
+      "fskey": [
+        "BA4p_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "BA6_exvivo": {
       "fskey": [
         "BA6_exvivo"
+      ],
+      "isAbout": null
+    },
+    "BA6_exvivo.thresh": {
+      "fskey": [
+        "BA6_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -537,6 +597,60 @@
     "G_Ins_lg&S_cent_ins": {
       "fskey": [
         "G_Ins_lg&S_cent_ins"
+      ],
+      "isAbout": null
+    },
+    "G_Ins_lg_and_S_cent_ins": {
+      "fskey": [
+        "G_Ins_lg_and_S_cent_ins"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_cingul-Ant": {
+      "fskey": [
+        "G_and_S_cingul-Ant"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_cingul-Mid-Ant": {
+      "fskey": [
+        "G_and_S_cingul-Mid-Ant"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_cingul-Mid-Post": {
+      "fskey": [
+        "G_and_S_cingul-Mid-Post"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_frontomargin": {
+      "fskey": [
+        "G_and_S_frontomargin"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_occipital_inf": {
+      "fskey": [
+        "G_and_S_occipital_inf"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_paracentral": {
+      "fskey": [
+        "G_and_S_paracentral"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_subcentral": {
+      "fskey": [
+        "G_and_S_subcentral"
+      ],
+      "isAbout": null
+    },
+    "G_and_S_transv_frontopol": {
+      "fskey": [
+        "G_and_S_transv_frontopol"
       ],
       "isAbout": null
     },
@@ -759,6 +873,12 @@
       ],
       "isAbout": null
     },
+    "MT_exvivo.thresh": {
+      "fskey": [
+        "MT_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "Mask": {
       "fskey": [
         "Mask"
@@ -881,6 +1001,12 @@
       ],
       "isAbout": null
     },
+    "S_intrapariet_and_P_trans": {
+      "fskey": [
+        "S_intrapariet_and_P_trans"
+      ],
+      "isAbout": null
+    },
     "S_oc-temp_lat": {
       "fskey": [
         "S_oc-temp_lat"
@@ -893,15 +1019,33 @@
       ],
       "isAbout": null
     },
+    "S_oc-temp_med_and_Lingual": {
+      "fskey": [
+        "S_oc-temp_med_and_Lingual"
+      ],
+      "isAbout": null
+    },
     "S_oc_middle&Lunatus": {
       "fskey": [
         "S_oc_middle&Lunatus"
       ],
       "isAbout": null
     },
+    "S_oc_middle_and_Lunatus": {
+      "fskey": [
+        "S_oc_middle_and_Lunatus"
+      ],
+      "isAbout": null
+    },
     "S_oc_sup&transversal": {
       "fskey": [
         "S_oc_sup&transversal"
+      ],
+      "isAbout": null
+    },
+    "S_oc_sup_and_transversal": {
+      "fskey": [
+        "S_oc_sup_and_transversal"
       ],
       "isAbout": null
     },
@@ -989,11 +1133,33 @@
       ],
       "isAbout": null
     },
+    "SegmentedTotalIntraCranialVol": {
+      "fskey": [],
+      "isAbout": null
+    },
+    "Straight-Sinus": {
+      "fskey": [
+        "Straight-Sinus"
+      ],
+      "isAbout": null
+    },
     "SubCortGray": {
       "fskey": [
         "SubCortGray"
       ],
       "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000955"
+    },
+    "Superior-Sinus-D": {
+      "fskey": [
+        "Superior-Sinus-D"
+      ],
+      "isAbout": null
+    },
+    "Superior-Sinus-P": {
+      "fskey": [
+        "Superior-Sinus-P"
+      ],
+      "isAbout": null
     },
     "SupraTentorial": {
       "fskey": [
@@ -1041,6 +1207,13 @@
       ],
       "isAbout": "http://purl.obolibrary.org/obo/UBERON_0005401"
     },
+    "Transverse-Sinus": {
+      "fskey": [
+        "Left-Transverse-Sinus",
+        "Right-Transverse-Sinus"
+      ],
+      "isAbout": null
+    },
     "UnsegmentedWhiteMatter": {
       "fskey": [
         "Left-UnsegmentedWhiteMatter",
@@ -1054,9 +1227,21 @@
       ],
       "isAbout": null
     },
+    "V1_exvivo.thresh": {
+      "fskey": [
+        "V1_exvivo.thresh"
+      ],
+      "isAbout": null
+    },
     "V2_exvivo": {
       "fskey": [
         "V2_exvivo"
+      ],
+      "isAbout": null
+    },
+    "V2_exvivo.thresh": {
+      "fskey": [
+        "V2_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -1121,6 +1306,12 @@
     "entoinal_exvivo": {
       "fskey": [
         "entorhinal_exvivo"
+      ],
+      "isAbout": null
+    },
+    "entoinal_exvivo.thresh": {
+      "fskey": [
+        "entorhinal_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -1237,6 +1428,12 @@
     "periinal_exvivo": {
       "fskey": [
         "perirhinal_exvivo"
+      ],
+      "isAbout": null
+    },
+    "periinal_exvivo.thresh": {
+      "fskey": [
+        "perirhinal_exvivo.thresh"
       ],
       "isAbout": null
     },
@@ -1371,6 +1568,13 @@
       "fskey": [
         "wm-lh-fusiform",
         "wm-rh-fusiform"
+      ],
+      "isAbout": null
+    },
+    "wm-gyrus-ambiens": {
+      "fskey": [
+        "wm-lh-gyrus-ambiens",
+        "wm-rh-gyrus-ambiens"
       ],
       "isAbout": null
     },

--- a/segstats_jsonld/mapping_data/freesurfermap.json
+++ b/segstats_jsonld/mapping_data/freesurfermap.json
@@ -1134,7 +1134,9 @@
       "isAbout": null
     },
     "SegmentedTotalIntraCranialVol": {
-      "fskey": [],
+      "fskey": [
+        "SegmentedTotalIntraCranialVol"
+      ],
       "isAbout": null
     },
     "Straight-Sinus": {

--- a/segstats_jsonld/tests/test_fs_to_nidm.py
+++ b/segstats_jsonld/tests/test_fs_to_nidm.py
@@ -9,68 +9,6 @@ from .. import fs_to_nidm as s
 datapath = mapping_data.__path__[0] + '/'
 testdatap = abspath('segstats_jsonld/tests/testdata/')
 
-def test_remap2json():
-    """
-    Test some basic functionality of remap2json
-    """
-
-    xlsx_file = join(datapath, 'ReproNimCDEs.xlsx')
-    aparc_example = join(testdatap, 'rh.aparc.stats')
-    asag_example = join(testdatap, 'aseg.stats')
-
-    # smoke test whether non-scraping works
-    for examplefile in [aparc_example, asag_example]:
-        header, tableinfo, measures, biggie = s.remap2json(xlsx_file,
-                                                             examplefile,
-                                                             noscrape=True
-                                                             )
-        # check that we have the overall keys assigned
-        assert "Anatomy" in biggie.keys()
-        assert "Measures" in biggie.keys()
-        # assert that definitions are not assigned if there is no base-mapper
-        if exists(join(datapath, 'jsonmap.json')):
-            # TODO
-            continue
-        else:
-            # if there is no remapping file present yet:
-            for d in ['Anatomy', 'Measures']:
-                for key, value in biggie[d].items():
-                    for k, v in biggie[d][key].items():
-                        if k == 'definition':
-                            assert v == ""
-
-    # smoke test whether scraping works
-    # TODO: This takes very long, will have to think of sth faster
-    if s.test_connection():
-        for examplefile in [aparc_example, asag_example]:
-            header, tableinfo, measures, biggie = s.remap2json(xlsx_file,
-                                                               examplefile,
-                                                               noscrape=False,
-                                                               force_update=True
-                                                                )
-            for d in ['Anatomy', 'Measures']:
-                for key, value in biggie[d].items():
-                    for k, v in biggie[d][key].items():
-                        if k == 'definition':
-                            assert v != np.nan
-
-            # check the correct definitions are retrieved for some example terms
-            if examplefile == aparc_example:
-                assert biggie['Anatomy']['Left-Lateral-Ventricle']['definition'] == \
-                    'lateral ventricle cerebral spinal fluid'
-                assert biggie['Measures']['SurfArea']['measureOf'] == 'http://uri.interlex.org/base/ilx_0738271'
-
-            elif examplefile == asag_example:
-                assert biggie['Measures']['NVoxels']['measureOf'] == 'http://uri.interlex.org/base/ilx_0105536'
-
-    # check whether we save valid json
-    with open(join(testdatap, 'tmpjson.json'), 'w') as f:
-        json.dump(biggie, f, indent=4)
-    # parsing this will fail if json is not valid
-    with open(join(testdatap, 'tmpjson.json'), 'r') as j:
-        json.load(j)
-
-
 def test_test_connection():
     """ smoke test to see whether this function tests internet connection"""
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
         "pandas",
         "prov",
         "xlrd",
-        "neurdflib",
-	"neurdflib-jsonld"
+        "rdflib>=6.0.0",
+        "rdflib-jsonld>=0.6.0"
     ],  # Add requirements as necessary
     include_package_data=True,
     extras_require={


### PR DESCRIPTION
### Issues Resolved:

#### 1. __Python 3.10 Compatibility__ ✅

- Replaced `neurdflib` → `rdflib>=6.0.0` (3 files updated)
- Fixed environment: Uninstalled neurdflib, installed rdflib 6.3.2

#### 2. __Missing FreeSurfer CDE Keys__ ✅

- thanks to @djarecka now we have added keys and support most `.stats` file
- see notes from (https://github.com/yibeichan/segstats_jsonld/pull/1)